### PR TITLE
🧪 Small test improvement

### DIFF
--- a/src/parsers/GmlReader.hx
+++ b/src/parsers/GmlReader.hx
@@ -173,7 +173,16 @@ using tools.NativeString;
 			c = peek();
 		}
 	}
+
+	/** Reads a number*/
+	public function readNumber():String {
+		var start = pos;
+		skipNumber();
+		return substring(start,pos);
+	}
+
 	
+	/**Skips the remainder of an already opened hex*/
 	public function skipHex():Void {
 		var c = peek();
 		while (loopLocal) {
@@ -182,6 +191,13 @@ using tools.NativeString;
 				c = peek();
 			} else break;
 		}
+	}
+
+	/** Reads the remainder of an already opened hex*/
+	public function readHex():String {
+		var start = pos;
+		skipHex();
+		return substring(start,pos);
 	}
 	
 	/** Reads the remainder of an already opened string */
@@ -212,6 +228,12 @@ using tools.NativeString;
 			};
 			default: return 0;
 		}
+	}
+
+	public function readStringAuto(startquote:CharCode):String {
+		var start = pos;
+		skipStringAuto(startquote, version);
+		return substring(start, pos-1); // -1 because pos went past the quote
 	}
 	
 	/** Skips spaces/tabs */
@@ -388,6 +410,37 @@ using tools.NativeString;
 			}
 		}
 		return n;
+	}
+
+	public function skipNopsTillNewline() {
+		while (pos < length) {
+			var c = peek();
+			switch (c) {
+				case " ".code, "\t".code, "\r".code: skip();
+				case "\n".code: skip(); return;
+				case "/".code: switch (peek(1)) {
+					case "/".code: skipLine();
+					case "*".code: skip(2);
+					default: break;
+				};
+				default: break;
+			}
+		}
+		return;
+	}
+
+	/** Reads comments and whitespace*/
+	public function readNops():String {
+		var start = pos;
+		skipNops();
+		return substring(start, pos);
+	}
+
+	/** Reads comments and whitespace until it encounters a new line*/
+	public function readNopsTillNewline():String {
+		var start = pos;
+		skipNopsTillNewline();
+		return substring(start, pos);
 	}
 	
 	/**

--- a/src/parsers/linter/GmlLinter.hx
+++ b/src/parsers/linter/GmlLinter.hx
@@ -196,7 +196,7 @@ class GmlLinter {
 	//
 	var keywords:Dictionary<GmlLinterKind>;
 	function initKeywords() {
-		keywords = GmlLinterInit.keywords(this);
+		keywords = GmlLinterInit.keywords(version.config);
 	}
 	
 	//

--- a/src/parsers/linter/GmlLinterInit.hx
+++ b/src/parsers/linter/GmlLinterInit.hx
@@ -1,4 +1,5 @@
 package parsers.linter;
+import gml.GmlVersionConfig;
 import parsers.linter.GmlLinterKind;
 import tools.Dictionary;
 
@@ -7,7 +8,7 @@ import tools.Dictionary;
  * @author YellowAfterlife
  */
 class GmlLinterInit {
-	public static function keywords(l:GmlLinter):Dictionary<GmlLinterKind> {
+	public static function keywords(config:GmlVersionConfig):Dictionary<GmlLinterKind> {
 		var q = new Dictionary<GmlLinterKind>();
 		q["var"] = KVar;
 		q["globalvar"] = KGlobalVar;
@@ -50,7 +51,7 @@ class GmlLinterInit {
 		q["finally"] = KFinally;
 		q["throw"] = KThrow;
 		//
-		var kws = @:privateAccess l.version.config.additionalKeywords;
+		var kws = config.additionalKeywords;
 		if (kws != null) {
 			inline function addOpt(name:String, k:GmlLinterKind) {
 				if (kws.indexOf(name) >= 0) q[name] = k;

--- a/tests/unittest/TestRunnerCustom.hx
+++ b/tests/unittest/TestRunnerCustom.hx
@@ -285,7 +285,7 @@ class TestRunnerCustom implements IAsyncDelegateObserver
     function executeTestCase(testCaseData:Dynamic, async:Bool)
     {
         var result:TestResult = testCaseData.result;
-        //try
+        try
         {
             var assertionCount:Int = Assert.assertionCount;
             if (async)
@@ -308,8 +308,11 @@ class TestRunnerCustom implements IAsyncDelegateObserver
                     c.addPass(result);
             }
         }
-        /*catch(e:Dynamic)
+        catch(e:Dynamic)
         {
+            if ((e is AssertionException) == false) {
+                throw e;
+            }
             if(async && asyncDelegate != null)
             {
                 asyncDelegate.cancelTest();
@@ -340,7 +343,7 @@ class TestRunnerCustom implements IAsyncDelegateObserver
                 for (c in clients)
                     c.addError(result);
             }
-        }*/
+        }
     }
 
     function clientCompletionHandler(resultClient:ITestResultClient)


### PR DESCRIPTION
Also adds reading methods to GmlReader.

This makes tests not throw when the result is wrong, but no exception happened.
Should make it easier when you've made a lot of tests (and makes them easier to read) while retaining debuggability.