### PR TITLE
🎮 Set primary color for gms2 theme

### DIFF
--- a/bin/resources/app/themes/gms2/gms2.css
+++ b/bin/resources/app/themes/gms2/gms2.css
@@ -1,3 +1,7 @@
+:root {
+	--color-primary: #0B9B80;
+}
+
 .chrome-tabs .chrome-tab-close {
   border-radius: 0px;
 }


### PR DESCRIPTION
Sets the primary color variable to the GMS2 color equivalent. Makes checkboxes, radios and selections a lot greener.

![image](https://user-images.githubusercontent.com/12459883/108128356-e4c91000-70ac-11eb-8009-c75b62999f16.png)
