### PR TITLE
➖ minus b gone

### DIFF
--- a/src/ace/AceGmlHighlight.hx
+++ b/src/ace/AceGmlHighlight.hx
@@ -524,7 +524,7 @@ using tools.NativeArray;
 		}
 		rBase = rBase.concat([ //{
 			rxRule("numeric", ~/(?:\$|0x)[0-9a-fA-F]*/), // $c0ffee
-			rxRule("numeric", ~/[+-]?\d+(?:\.\d*)?/), // 42.5 (GML has no E# suffixes)
+			rxRule("numeric", ~/\d+(?:\.\d*)?/), // 42.5 (GML has no E# suffixes)
 			rxRule("constant.boolean", ~/(?:true|false)\b/),
 			rxPush(["keyword", "text", "enum"], ~/(enum)(\s+)(\w+)/, "gml.enum"),
 			rxRule(function(goto, _, label) {


### PR DESCRIPTION
Removes the - from being captured by the number regex. Fixes -0xc0ffee not being captured as a number.