### PR TITLE
Private variables explicit typing fix

### DIFF
--- a/src/parsers/GmlSeeker.hx
+++ b/src/parsers/GmlSeeker.hx
@@ -566,8 +566,9 @@ class GmlSeeker {
 			if (type != null) info = NativeString.nzcct(info, "\n", "type " + type.toString());
 			
 			var compMeta = isField ? (args != null ? "function" : "variable") : "namespace";
-			var comp = privateFieldRegex == null || !privateFieldRegex.test(s)
-				? new AceAutoCompleteItem(name, compMeta, info) : null;
+			var compName = privateFieldRegex == null || !privateFieldRegex.test(s)
+				? name : "";
+			var comp = new AceAutoCompleteItem(compName, compMeta, info);
 			var hint = new GmlSeekDataHint(namespace, isInst, field, comp, hintDoc, parentSpace, type);
 			
 			var lastHint = out.fieldHints[hint.key];


### PR DESCRIPTION
Fixed: using a private variable with explicit type leads to an error:
![image](https://user-images.githubusercontent.com/27915583/109425193-343a0500-79f8-11eb-949f-cad4f8229f07.png)
![image](https://user-images.githubusercontent.com/27915583/109425139-f63ce100-79f7-11eb-9fe1-cbc3ac9322b3.png)

Not sure if it's a correct fix, but it seems to work fine.
