### PR TITLE
Fix outline-view plugin ignoring display mode

### DIFF
--- a/bin/resources/app/plugins/outline-view/outline-view.js
+++ b/bin/resources/app/plugins/outline-view/outline-view.js
@@ -543,14 +543,14 @@
 		changeTo(e.file);
 	}
 	function onFileClose(e) {
-		syncAll();
+		if (!currOnly) syncAll();
 	}
 	function onFileSave(e) {
 		reindex(e.file);
 		update(e.file);
 	}
 	function onTabsReorder(e) {
-		syncAll(e.target.tabEls);
+		if (!currOnly) syncAll(e.target.tabEls);
 	}
 	// update current subitem on editor navigation
 	var onUpdate_scheduled = false;


### PR DESCRIPTION
Fix for an obscure bug that only appears when outline-view display mode is set to "Only show the currently active document" and certain tab/file events are fired.