### PR TITLE
emit 'tabsReorder' event when using multiline tabs

### DIFF
--- a/bin/resources/app/chrome-tabs/chrome-tabs.js
+++ b/bin/resources/app/chrome-tabs/chrome-tabs.js
@@ -472,6 +472,7 @@
             source.parentElement.insertBefore(source, target)
             this.simpleDragTab = null
             this.layoutTabs()
+            GMEdit._emit("tabsReorder", {target:this})
           },
         }
         for (let prop in events) events[prop] = events[prop].bind(this)


### PR DESCRIPTION
When chromeTabs is using simpleDrag, the tabsReorder event should be emitted.