### PR TITLE
Fix for Sprite Editor not allowing the importing of images on macOS

### DIFF
--- a/src/editors/sprite/EditSprite.hx
+++ b/src/editors/sprite/EditSprite.hx
@@ -185,7 +185,7 @@ class EditSprite extends Editor {
 		Dialog.showOpenDialog({
 			title: "Open",
 			buttonLabel: "Import",
-			properties: [ DialogOpenFeature.multiSelections ],
+			properties: [ DialogOpenFeature.openFile, DialogOpenFeature.multiSelections ],
 			filters: [
 				new DialogFilter( "Image files", ["png"])
 			]


### PR DESCRIPTION
Add OpenDialog property 'openFile' on Import Images button, to allow the selection of files on macOS.