### PR TITLE
Added docs tooltip plugin

### DIFF
--- a/bin/resources/app/plugins/docs-tooltips/config.json
+++ b/bin/resources/app/plugins/docs-tooltips/config.json
@@ -1,0 +1,5 @@
+{
+  "name": "docs-tooltips",
+  "description": "Provides detailed tooltips with information from the latest official documentation.",
+  "scripts": ["docs-tooltips.js"]
+}

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -13,11 +13,13 @@
 
       if (!Preferences.current.docs_tooltips) Preferences.current.docs_tooltips = {
         enabled: true,
-        strictLatest: false
+        strictLatest: false,
+        keys: []
       };
 
       state.enabled = Preferences.current.docs_tooltips.enabled;
       state.strictLatest = Preferences.current.docs_tooltips.strictLatest;
+      state.keys = Preferences.current.docs_tooltips.keys;
 
       const ogSetText = aceEditor.tooltipManager.ttip.setText;
       aceEditor.tooltipManager.ttip.setText = function() {
@@ -62,7 +64,11 @@
   function downloadLatestDocs() {
     fetch('https://raw.githubusercontent.com/christopherwk210/gm-bot/master/static/docs-index.json')
       .then(res => res.json())
-      .then(data => state.keys = data.keys)
+      .then(data => {
+        state.keys = data.keys;
+        Preferences.current.docs_tooltips.keys = data.keys;
+        Preferences.save();
+      })
       .catch(() => console.error('docs-tooltips: failed to fetch documentation'));
   }
   

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -1,97 +1,70 @@
-const Preferences = $gmedit['ui.Preferences'];
-
-window.__gm_docs_tooltips = {
-  enabled: true,
-  replaced: false,
-  replacedText: '',
-  preReplacement: '',
-  keys: [],
-  timer: -1
-};
-
-GMEdit.register('docs-tooltips', {
-  init: () => {
-    if (!Preferences.current.docs_tooltips) Preferences.current.docs_tooltips = { enabled: true };
-    window.__gm_docs_tooltips.enabled = Preferences.current.docs_tooltips.enabled;
-    window.__gm_docs_tooltips.timer = createTimer();
-  },
-  cleanup: () => {
-    clearInterval(window.__gm_docs_tooltips.timer);
-  }
-});
-
-GMEdit.on('preferencesBuilt', function(e) {
-  var out = e.target.querySelector('.plugin-settings[for="docs-tooltips"]');
-
-  Preferences.addCheckbox(out, 'Enabled', window.__gm_docs_tooltips.enabled, () => {
-    window.__gm_docs_tooltips.enabled = !window.__gm_docs_tooltips.enabled;
-    Preferences.current.docs_tooltips.enabled = window.__gm_docs_tooltips.enabled;
-    Preferences.save();
-  });
-});
-
-fetch('https://raw.githubusercontent.com/christopherwk210/gm-bot/master/static/docs-index.json')
-.then(res => res.json())
-.then(data => window.__gm_docs_tooltips.keys = data.keys)
-.catch(() => console.error('docs-tooltips: failed to fetch documentation'))
-
-function getTooltipText() {
-  if (aceEditor.tooltipManager.ttip.$element) return aceEditor.tooltipManager.ttip.$element.innerHTML;
-}
-
-function setTooltipText(html = '') {
-  if (aceEditor.tooltipManager.ttip.$element) aceEditor.tooltipManager.ttip.$element.innerHTML = html;
-}
-
-function createTimer() {
-  return setInterval(() => {
-    if (!window.__gm_docs_tooltips.enabled) return;
-
-    if (aceEditor.tooltipManager.ttip.isOpen) {
-      if (getTooltipText() !== window.__gm_docs_tooltips.replacedText) window.__gm_docs_tooltips.replaced = false;
+(() => {
+  const Preferences = $gmedit['ui.Preferences'];
   
-      if (!window.__gm_docs_tooltips.replaced) {
-        const existingText = getTooltipText();
-        const keyName = existingText.split('(')[0];
-        const returnValue = existingText.split('➜')[1];
+  const state = {
+    enabled: true,
+    keys: []
+  };
   
-        const foundItem = window.__gm_docs_tooltips.keys.find(item => item.name === keyName);
+  GMEdit.register('docs-tooltips', {
+    init: () => {
+      if (!Preferences.current.docs_tooltips) Preferences.current.docs_tooltips = { enabled: true };
+
+      const ogSetText = aceEditor.tooltipManager.ttip.setText;
+      aceEditor.tooltipManager.ttip.setText = function() {
+        const text = arguments[0];
+        const returnValue = text.split('➜')[1];
+
+        const foundItem = state.keys.find(item => item.name === text.split('(')[0]);
         if (foundItem && foundItem.topics.length === 1) {
           const key = foundItem;
-          const text = createTooltipHTML(key, returnValue);
-  
-          window.__gm_docs_tooltips.replaced = true;
-          window.__gm_docs_tooltips.replacedText = text;
-          window.__gm_docs_tooltips.preReplacement = existingText;
-          setTooltipText(window.__gm_docs_tooltips.replacedText);
+          const html = createTooltipHTML(key, returnValue);
+
+          aceEditor.tooltipManager.ttip.setHtml.apply(this, [html]);
+        } else {
+          ogSetText.apply(this, arguments);
         }
       }
-    } else {
-      window.__gm_docs_tooltips.replaced = false;
-      window.__gm_docs_tooltips.replacedText = '';
-      setTooltipText(window.__gm_docs_tooltips.preReplacement)
+  
+      state.enabled = Preferences.current.docs_tooltips.enabled;
+    },
+    cleanup: () => {}
+  });
+  
+  GMEdit.on('preferencesBuilt', function(e) {
+    var out = e.target.querySelector('.plugin-settings[for="docs-tooltips"]');
+  
+    Preferences.addCheckbox(out, 'Enabled', state.enabled, () => {
+      state.enabled = !state.enabled;
+      Preferences.current.docs_tooltips.enabled = state.enabled;
+      Preferences.save();
+    });
+  });
+  
+  fetch('https://raw.githubusercontent.com/christopherwk210/gm-bot/master/static/docs-index.json')
+  .then(res => res.json())
+  .then(data => state.keys = data.keys)
+  .catch(() => console.error('docs-tooltips: failed to fetch documentation'));
+  
+  function createTooltipHTML(key, returnValue) {
+    const topic = key.topics[0];
+  
+    const title = key.name === topic.name ? (topic.syntax || key.name) : `${key.name} - ${topic.name}`;
+  
+    let description = `<p>${topic.blurb}</p>`;
+    if (topic.args && topic.args.length) {
+      description += `<div style="margin-bottom: 0.25em; border-bottom: 1px solid #495057;">Arguments</div>`;
+      for (const arg of topic.args) {
+        description += `<div style="margin-bottom: 0.25em"><strong style="color: #039E5C;">${arg.argument}</strong>: ${arg.description.replace('`OPTIONAL`', '(Optional)')}</div>`;
+      }
     }
-  }, 100);
-}
-
-function createTooltipHTML(key, returnValue) {
-  const topic = key.topics[0];
-
-  const title = key.name === topic.name ? (topic.syntax || key.name) : `${key.name} - ${topic.name}`;
-
-  let description = `<p>${topic.blurb}</p>`;
-  if (topic.args && topic.args.length) {
-    description += `<div style="margin-bottom: 0.25em; border-bottom: 1px solid #495057;">Arguments</div>`;
-    for (const arg of topic.args) {
-      description += `<div style="margin-bottom: 0.25em"><strong style="color: #039E5C;">${arg.argument}</strong>: ${arg.description.replace('`OPTIONAL`', '(Optional)')}</div>`;
-    }
+  
+    let text = `<h4 style="color: #FFB871; margin: 0; border-bottom: 1px solid #495057; padding-bottom: 8px;">${title}➜${returnValue}</h4>`;
+  
+    text += '<div style="max-width: 400px; white-space: normal;">';
+    text += description;
+    text += '</div>';
+  
+    return text;
   }
-
-  let text = `<h4 style="color: #FFB871; margin: 0; border-bottom: 1px solid #495057; padding-bottom: 8px;">${title}➜${returnValue}</h4>`;
-
-  text += '<div style="max-width: 400px; white-space: normal;">';
-  text += description;
-  text += '</div>';
-
-  return text;
-}
+})();

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -1,0 +1,97 @@
+const Preferences = $gmedit['ui.Preferences'];
+
+window.__gm_docs_tooltips = {
+  enabled: true,
+  replaced: false,
+  replacedText: '',
+  preReplacement: '',
+  keys: [],
+  timer: -1
+};
+
+GMEdit.register('docs-tooltips', {
+  init: () => {
+    if (!Preferences.current.docs_tooltips) Preferences.current.docs_tooltips = { enabled: true };
+    window.__gm_docs_tooltips.enabled = Preferences.current.docs_tooltips.enabled;
+    window.__gm_docs_tooltips.timer = createTimer();
+  },
+  cleanup: () => {
+    clearInterval(window.__gm_docs_tooltips.timer);
+  }
+});
+
+GMEdit.on('preferencesBuilt', function(e) {
+  var out = e.target.querySelector('.plugin-settings[for="docs-tooltips"]');
+
+  Preferences.addCheckbox(out, 'Enabled', window.__gm_docs_tooltips.enabled, () => {
+    window.__gm_docs_tooltips.enabled = !window.__gm_docs_tooltips.enabled;
+    Preferences.current.docs_tooltips.enabled = window.__gm_docs_tooltips.enabled;
+    Preferences.save();
+  });
+});
+
+fetch('https://raw.githubusercontent.com/christopherwk210/gm-bot/master/static/docs-index.json')
+.then(res => res.json())
+.then(data => window.__gm_docs_tooltips.keys = data.keys)
+.catch(() => console.error('docs-tooltips: failed to fetch documentation'))
+
+function getTooltipText() {
+  if (aceEditor.tooltipManager.ttip.$element) return aceEditor.tooltipManager.ttip.$element.innerHTML;
+}
+
+function setTooltipText(html = '') {
+  if (aceEditor.tooltipManager.ttip.$element) aceEditor.tooltipManager.ttip.$element.innerHTML = html;
+}
+
+function createTimer() {
+  return setInterval(() => {
+    if (!window.__gm_docs_tooltips.enabled) return;
+
+    if (aceEditor.tooltipManager.ttip.isOpen) {
+      if (getTooltipText() !== window.__gm_docs_tooltips.replacedText) window.__gm_docs_tooltips.replaced = false;
+  
+      if (!window.__gm_docs_tooltips.replaced) {
+        const existingText = getTooltipText();
+        const keyName = existingText.split('(')[0];
+        const returnValue = existingText.split('➜')[1];
+  
+        const foundItem = window.__gm_docs_tooltips.keys.find(item => item.name === keyName);
+        if (foundItem && foundItem.topics.length === 1) {
+          const key = foundItem;
+          const text = createTooltipHTML(key, returnValue);
+  
+          window.__gm_docs_tooltips.replaced = true;
+          window.__gm_docs_tooltips.replacedText = text;
+          window.__gm_docs_tooltips.preReplacement = existingText;
+          setTooltipText(window.__gm_docs_tooltips.replacedText);
+        }
+      }
+    } else {
+      window.__gm_docs_tooltips.replaced = false;
+      window.__gm_docs_tooltips.replacedText = '';
+      setTooltipText(window.__gm_docs_tooltips.preReplacement)
+    }
+  }, 100);
+}
+
+function createTooltipHTML(key, returnValue) {
+  const topic = key.topics[0];
+
+  const title = key.name === topic.name ? (topic.syntax || key.name) : `${key.name} - ${topic.name}`;
+
+  let description = `<p>${topic.blurb}</p>`;
+  if (topic.args && topic.args.length) {
+    description += `<div style="margin-bottom: 0.25em; border-bottom: 1px solid #495057;">Arguments</div>`;
+    for (const arg of topic.args) {
+      description += `<div style="margin-bottom: 0.25em"><strong style="color: #039E5C;">${arg.argument}</strong>: ${arg.description.replace('`OPTIONAL`', '(Optional)')}</div>`;
+    }
+  }
+
+  let text = `<h4 style="color: #FFB871; margin: 0; border-bottom: 1px solid #495057; padding-bottom: 8px;">${title}➜${returnValue}</h4>`;
+
+  text += '<div style="max-width: 400px; white-space: normal;">';
+  text += description;
+  text += '</div>';
+
+  return text;
+}


### PR DESCRIPTION
Requesting to PR [this plugin](https://github.com/christopherwk210/gmedit-docs-tooltip) into master, to provide official GM documentation snippets inside of function tooltips.

Some concerns, in no particular order, that may or may not even need to be addressed:

- This feature relies on an internet connection to work, since it fetches an auto-generated JSON scrape of the official documentation, which can be found [here](https://raw.githubusercontent.com/christopherwk210/gm-bot/master/static/docs-index.json). This file is kept up to date by me for the purpose of powering [gm-bot](https://github.com/christopherwk210/gm-bot). If the file can't be fetched, then it fails silently with no indication to the user. Might be worth making a mention of that somewhere?
- This plugin uses the latest documentation available from YYG, but it does not detect if the user is using GMEdit to edit an older project. If the user is working on a GM 8.1 project for instance, there may be inconsistencies in the documentation provided, if newer versions of the function have been changed. Adding that detection could be worth it, or we can just trust the user to turn it off when its not needed.
- A `setInterval` is used to keep a watch over tooltip activity to make the feature work. There is a (admittedly low) performance hit associated with having an interval running, so exposing some kind of plugin hook for tooltips could solve that. Not sure if that's worth it though. It's probably fine. As a "sub-concern" this also means that tooltips might flicker before being updated, but that's not really a big issue.