### PR TITLE
Fix global quit shortcut by moving it to the context menu on MacOS.

### DIFF
--- a/bin/resources/app/main.js
+++ b/bin/resources/app/main.js
@@ -70,11 +70,6 @@ function createWindow(first) {
 	})
 	if (!isMac) {
 		wnd.removeMenu()
-	} else {
-		// https://memorytin.com/2018/04/24/electron-js-handle-cmdq-in-os-x/
-		electron.globalShortcut.register('Command+Q', () => {
-			app.quit();
-		})
 	}
 	activeWindows.push(wnd)
 	if (showOnceReady) {

--- a/src/ace/AceCtxMenu.hx
+++ b/src/ace/AceCtxMenu.hx
@@ -1,6 +1,7 @@
 package ace;
 import ace.extern.AcePos;
 import ace.extern.AceToken;
+import electron.AppTools;
 import electron.Clipboard;
 import electron.Electron;
 import electron.FileWrap;
@@ -166,6 +167,19 @@ class AceCtxMenu {
 					editor.execCommand("paste", cb().readText());
 				}
 			});
+
+			if(FileWrap.isMac) {
+				menu.appendOpt({
+					id: "quit",
+					label: "Quit",
+					role: "quit",
+					icon: Menu.silkIcon("stop"),
+					accelerator: "command+Q",
+					click: function() {
+						AppTools.quit();
+					}
+				});
+			}
 		}
 		//
 		menu.appendSep("sep-select");

--- a/src/ace/AceCtxMenu.hx
+++ b/src/ace/AceCtxMenu.hx
@@ -167,19 +167,6 @@ class AceCtxMenu {
 					editor.execCommand("paste", cb().readText());
 				}
 			});
-
-			if(FileWrap.isMac) {
-				menu.appendOpt({
-					id: "quit",
-					label: "Quit",
-					role: "quit",
-					icon: Menu.silkIcon("stop"),
-					accelerator: "command+Q",
-					click: function() {
-						AppTools.quit();
-					}
-				});
-			}
 		}
 		//
 		menu.appendSep("sep-select");
@@ -201,10 +188,21 @@ class AceCtxMenu {
 		// So we'll bind the one attached to main code editor, whatever
 		if (Electron == null || !FileWrap.isMac) return;
 		var menu = new Menu();
+		var editSubMenu = editor.contextMenu.menu;
+		editSubMenu.appendOpt({
+			id: "quit",
+			label: "Quit",
+			role: "quit",
+			icon: Menu.silkIcon("stop"),
+			accelerator: "command+Q",
+			click: function() {
+				AppTools.quit();
+			}
+		});
 		menu.appendOpt({
 			id: "sub-edit",
 			label: "Edit",
-			submenu: editor.contextMenu.menu,
+			submenu: editSubMenu,
 		});
 		Menu.setApplicationMenu(menu);
 	}

--- a/src/electron/AppTools.hx
+++ b/src/electron/AppTools.hx
@@ -7,7 +7,8 @@ package electron;
 @:native("Electron_App") extern class AppTools {
 	static function getAppPath():String;
 	static function getPath(kind:String):String;
-	
+	static function quit():Void;
+
 	/** Windows-only! */
 	static function setUserTasks(arr:Array<AppUserTask>):Void;
 	


### PR DESCRIPTION
Resolves an issue where using 'Command+Q' would inadvertently quit GMEdit on MacOS, even when the editor wasn't in focus. The quit command, along with its shortcut, has now been added to the context menu, ensuring the app only closes when intended and preventing accidental exits while working in other applications.

![CleanShot 2024-03-16 at 01 38 13](https://github.com/YellowAfterlife/GMEdit/assets/3180866/ae5be823-1c6c-48e3-b3b2-93589370691e)