### PR TITLE
Complex parsing of built-in structs

### DIFF
--- a/src/parsers/GmlParseAPI.hx
+++ b/src/parsers/GmlParseAPI.hx
@@ -131,7 +131,7 @@ class GmlParseAPI {
 				return;
 			}
 			var typeStr = mt[2];
-			var type = GmlTypeDef.simple(typeStr);
+			var type = GmlTypeDef.parse(typeStr, currStruct);
 			var cinf = "from " + currStruct;
 			if (typeStr != null) cinf += "\ntype " + typeStr;
 			var comp = new AceAutoCompleteItem(name, "variable", cinf);


### PR DESCRIPTION
Currently because of using `GmlTypeDef.simple` while parsing fields in built-in struct declarations (??structname) you can't hint them as complex types or collections. That may result, for example, in quirky warnings:

```js
var infos:room_info_instance[] = room_get_info(roomCheck, false, true, false, false, false).instances;
// shows "can't cast Array<room_info_instance> to Array<room_info_instance>" ???
```

Changing it to full `GmlTypeDef.parse` fixes the issue.