### PR TITLE
Add ability to @is anonymous structs

### DIFF
--- a/src/parsers/seeker/GmlSeekerJSDocRegex.hx
+++ b/src/parsers/seeker/GmlSeekerJSDocRegex.hx
@@ -58,7 +58,7 @@ class GmlSeekerJSDocRegex {
 	
 	public static var jsDoc_is = new RegExp("^///\\s*"
 		+ "@is\\b\\s*"
-		+ "(?:\\{(.+?)\\}\\s*)?" // type (opt.)
+		+ "(?:\\{(.+)\\}\\s*)?" // type (opt.)
 		+ "(.*)"
 	);
 	public static var jsDoc_is_line = (function() {


### PR DESCRIPTION
Currently, something like
```js
arrayOfAnonStructs = [];    /// @is {Array<{ one:int, two:int, three:int }>}
```
is not possible as the regex stops on the first closed curly brace.

This fixes it.

Correct work is checked on:
```js
/// @is {type}
/// @is {type} comment
/// @is desc
```