### PR TITLE
Fix trailing data warning for [optional] jsdoc arguments

### DIFF
--- a/src/gml/funcdoc/GmlFuncDocParser.hx
+++ b/src/gml/funcdoc/GmlFuncDocParser.hx
@@ -106,7 +106,7 @@ class GmlFuncDocParser {
 			var rxt = rxArgType;
 			var showArgTypes = Preferences.current.showArgTypesInStatusBar;
 			for (i => arg in args) {
-				var hadBrackets = !showArgTypes && arg.startsWith("[") && arg.endsWith("]");
+				var hadBrackets = arg.startsWith("[") && arg.endsWith("]");
 				if (hadBrackets) arg = arg.substring(1, arg.length - 1);
 				arg = arg.replaceExt(rxt, function(argStr, t1, t2) {
 					var typeStr = JsTools.or(t1, t2).trimRight();


### PR DESCRIPTION
This fixes this warning:
![GMEdit_tXSXYDMVsR](https://github.com/user-attachments/assets/036bd23e-9520-4cb3-8e8d-6db51c442d61)

It seems that `showArgTypes` check is not needed there and it checks for it again on return anyways.