### PR TITLE
Fix `outline-view` not updating file names on renaming + Plugin API addition

### DIFF
--- a/bin/resources/app/plugins/outline-view/outline-view.js
+++ b/bin/resources/app/plugins/outline-view/outline-view.js
@@ -342,17 +342,15 @@
 	var currEl = null;
 	//
 	function currFile() { return $gmedit["gml.file.GmlFile"].current; }
-	// maybe this should be a "built-in" function instead
+	
+	/**
+	 * Focus the given file's tab.
+	 * @param {GMEdit.GmlFile} file
+	 */
 	function activateFile(file) {
-		var tabs = document.querySelectorAll(".chrome-tab");
-		for (var i = 0; i < tabs.length; i++) {
-			if (tabs[i].gmlFile == file) {
-				tabs[i].click();
-				return tabs[i];
-			}
-		}
-		return null;
+		file.tabEl?.click();
 	}
+
 	//
 	var TreeView = $gmedit["ui.treeview.TreeView"];
 	var makeDir = TreeView.makeDir;
@@ -382,10 +380,21 @@
 			}
 		});
 	}
+
+	/**
+	 * Change the label for the given navigation item.
+	 * 
+	 * @param {HTMLDivElement} item 
+	 * @param {string} label 
+	 */
+	function setNavItemLabel(item, label) {
+		item.treeHeader.querySelector("span.label").textContent = label;
+	}
+
 	function makeNav(file, label, title, nav) {
 		var r = navPool.pop();
 		if (r) {
-			r.querySelector(".header span").textContent = label;
+			setNavItemLabel(r, label);
 		} else {
 			r = makeDir(label);
 			r.classList.add("outline-item");
@@ -678,6 +687,29 @@
 			} else outer.parentElement.removeChild(outer);
 		}
 	}
+
+	/**
+	 * Update a file's name and path in the outline view when it is modified.
+	 * @param {{ file: GMEdit.GmlFile }} event 
+	 */
+	function onFileRename({ file }) {
+		
+		const tab = file.tabEl;
+		
+		if (tab === null) {
+			return;
+		}
+		
+		if (currOnly && file !== currFile()) {
+			return;
+		}
+
+		if ('outlineView' in file) {
+			setNavItemLabel(file.outlineView, file.name);
+		}
+
+	}
+
 	function init() {
 		AceCommands.add({
 			name: "toggleOutlineView",
@@ -761,7 +793,11 @@
 				forceRefresh();
 			});
 		});
+		
+		GMEdit.on("fileRename", onFileRename);
+
 	}
+
 	GMEdit.register("outline-view", {
 		init: init,
 		cleanup: function() {
@@ -769,4 +805,5 @@
 		},
 		_modeMap: modeMap
 	});
+
 })();

--- a/bin/resources/app/plugins/outline-view/outline-view.js
+++ b/bin/resources/app/plugins/outline-view/outline-view.js
@@ -694,12 +694,6 @@
 	 */
 	function onFileRename({ file }) {
 		
-		const tab = file.tabEl;
-		
-		if (tab === null) {
-			return;
-		}
-		
 		if (currOnly && file !== currFile()) {
 			return;
 		}
@@ -793,7 +787,7 @@
 				forceRefresh();
 			});
 		});
-		
+
 		GMEdit.on("fileRename", onFileRename);
 
 	}

--- a/bin/resources/app/plugins/outline-view/outline-view.js
+++ b/bin/resources/app/plugins/outline-view/outline-view.js
@@ -693,10 +693,6 @@
 	 * @param {{ file: GMEdit.GmlFile }} event 
 	 */
 	function onFileRename({ file }) {
-		
-		if (currOnly && file !== currFile()) {
-			return;
-		}
 
 		if ('outlineView' in file) {
 			setNavItemLabel(file.outlineView, file.name);

--- a/src/gml/file/GmlFile.hx
+++ b/src/gml/file/GmlFile.hx
@@ -198,6 +198,8 @@ class GmlFile {
 			this.tabEl.refresh();
 		}
 		
+		PluginEvents.fileRename({ file: this });
+
 	}
 
 	//

--- a/src/gml/file/GmlFile.hx
+++ b/src/gml/file/GmlFile.hx
@@ -188,10 +188,16 @@ class GmlFile {
 		ui.ChromeTabs.addTab(file.name);
 	}
 	public function rename(newName:String, newPath:String) {
+		
 		this.name = newName;
 		this.path = newPath;
 		//
 		this.context = kind.getTabContext(this, {});
+
+		if (this.tabEl != null) {
+			this.tabEl.refresh();
+		}
+		
 	}
 
 	//

--- a/src/plugins/PluginEvents.hx
+++ b/src/plugins/PluginEvents.hx
@@ -78,6 +78,11 @@ extern class PluginEvents {
 	 * (automatically or with user permit)
 	 */
 	static function fileReload(e:{file:GmlFile}):Void;
+
+	/**
+	 * Dispatches after a file's name or path changes.
+	 */
+	static function fileRename(e:{file:GmlFile}):Void;
 	
 	/**
 	 * Called after constructing the preferences menu.

--- a/src/ui/treeview/TreeViewItemMenus.hx
+++ b/src/ui/treeview/TreeViewItemMenus.hx
@@ -430,7 +430,6 @@ class TreeViewItemMenus {
 				var chromeTab:ChromeTab = cast tab;
 				if (chromeTab.gmlFile.path == oldPath) {
 					chromeTab.gmlFile.rename(s, el.treeFullPath);
-					chromeTab.refresh();
 				}
 			}
 		});


### PR DESCRIPTION
Currently, the bundled `outline-view` plugin will not update the name of files in the tree when they are renamed in the project.

As this is a bundled plugin it has the luxury of being in sync with a specific GMEdit version, so I went ahead and exposed a new plugin event that fires whenever a file is renamed, which thus facilitates keeping in-sync with file name changes in the plugin.

Additionally I've moved the responsibility of refreshing a file's tab to happen within `file.rename` rather than being done manually at the callsite. This makes it a lot less of a pain to rename files from a plugin, since currently you're forced to mirror GMEdit's behaviour by manually editing the tab element, rather than renaming a file keeping this in line itself.