### PR TITLE
fix: redundant `@:keep` annotation on plugin api

### DIFF
--- a/src/plugins/PluginAPI.hx
+++ b/src/plugins/PluginAPI.hx
@@ -7,7 +7,7 @@ import ace.AceTools;
  * Exposes a globally visible GMEdit object that you can use for some random bits
  * @author YellowAfterlife
  */
-@:keep @:expose("GMEdit")
+@:expose("GMEdit")
 class PluginAPI {
 	
 	/**


### PR DESCRIPTION
Tiniest PR for something so very unimportant :P

https://github.com/HaxeFoundation/haxe/issues/7695 is closed, so this is no longer necessary.