### PR TITLE
feat: enable and disable plugins at will!

### DIFF
--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -23,6 +23,8 @@
     });
   }
   
+  const ogSetText = aceEditor.tooltipManager.ttip.setText;
+
   GMEdit.register('docs-tooltips', {
     init: () => {
 
@@ -40,7 +42,6 @@
       state.strictLatest = Preferences.current.docs_tooltips.strictLatest;
       state.keys = Preferences.current.docs_tooltips.keys;
 
-      const ogSetText = aceEditor.tooltipManager.ttip.setText;
       aceEditor.tooltipManager.ttip.setText = function() {
         if (!state.enabled
           || (state.strictLatest && $gmedit['gml.Project'].current.version.name != 'v23')
@@ -73,6 +74,7 @@
     },
     cleanup: () => {
       GMEdit.off('preferencesBuilt', onPreferencesBuilt);
+      aceEditor.tooltipManager.ttip.setText = ogSetText;
     }
   });
 

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -30,7 +30,6 @@
   /** @type {Record<string, ManualEntry>} */
   let keys = {};
 
-  keys = null;
   GMEdit.register('docs-tooltips', {
     init: () => {
 

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -6,9 +6,28 @@
     strictLatest: false,
     keys: []
   };
+
+  function onPreferencesBuilt(e) {
+    var out = e.target.querySelector('.plugin-settings[for="docs-tooltips"]');
+  
+    Preferences.addCheckbox(out, 'Enabled', state.enabled, () => {
+      state.enabled = !state.enabled;
+      Preferences.current.docs_tooltips.enabled = state.enabled;
+      Preferences.save();
+    });
+
+    Preferences.addCheckbox(out, 'Disable for non GMS2.3+ projects', state.strictLatest, () => {
+      state.strictLatest = !state.strictLatest;
+      Preferences.current.docs_tooltips.strictLatest = state.strictLatest;
+      Preferences.save();
+    });
+  }
   
   GMEdit.register('docs-tooltips', {
     init: () => {
+
+      GMEdit.on('preferencesBuilt', onPreferencesBuilt);
+
       downloadLatestDocs();
 
       if (!Preferences.current.docs_tooltips) Preferences.current.docs_tooltips = {
@@ -52,23 +71,9 @@
         }
       }
     },
-    cleanup: () => {}
-  });
-  
-  GMEdit.on('preferencesBuilt', function(e) {
-    var out = e.target.querySelector('.plugin-settings[for="docs-tooltips"]');
-  
-    Preferences.addCheckbox(out, 'Enabled', state.enabled, () => {
-      state.enabled = !state.enabled;
-      Preferences.current.docs_tooltips.enabled = state.enabled;
-      Preferences.save();
-    });
-
-    Preferences.addCheckbox(out, 'Disable for non GMS2.3+ projects', state.strictLatest, () => {
-      state.strictLatest = !state.strictLatest;
-      Preferences.current.docs_tooltips.strictLatest = state.strictLatest;
-      Preferences.save();
-    });
+    cleanup: () => {
+      GMEdit.off('preferencesBuilt', onPreferencesBuilt);
+    }
   });
 
   function downloadLatestDocs() {

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -6,29 +6,11 @@
     strictLatest: false,
     keys: []
   };
-
-  function onPreferencesBuilt(e) {
-    var out = e.target.querySelector('.plugin-settings[for="docs-tooltips"]');
-  
-    Preferences.addCheckbox(out, 'Enabled', state.enabled, () => {
-      state.enabled = !state.enabled;
-      Preferences.current.docs_tooltips.enabled = state.enabled;
-      Preferences.save();
-    });
-
-    Preferences.addCheckbox(out, 'Disable for non GMS2.3+ projects', state.strictLatest, () => {
-      state.strictLatest = !state.strictLatest;
-      Preferences.current.docs_tooltips.strictLatest = state.strictLatest;
-      Preferences.save();
-    });
-  }
   
   const ogSetText = aceEditor.tooltipManager.ttip.setText;
 
   GMEdit.register('docs-tooltips', {
     init: () => {
-
-      GMEdit.on('preferencesBuilt', onPreferencesBuilt);
 
       downloadLatestDocs();
 
@@ -73,8 +55,22 @@
       }
     },
     cleanup: () => {
-      GMEdit.off('preferencesBuilt', onPreferencesBuilt);
       aceEditor.tooltipManager.ttip.setText = ogSetText;
+    },
+    buildPreferences: (out) => {
+    
+      Preferences.addCheckbox(out, 'Enabled', state.enabled, () => {
+        state.enabled = !state.enabled;
+        Preferences.current.docs_tooltips.enabled = state.enabled;
+        Preferences.save();
+      });
+  
+      Preferences.addCheckbox(out, 'Disable for non GMS2.3+ projects', state.strictLatest, () => {
+        state.strictLatest = !state.strictLatest;
+        Preferences.current.docs_tooltips.strictLatest = state.strictLatest;
+        Preferences.save();
+      });
+
     }
   });
 

--- a/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
+++ b/bin/resources/app/plugins/docs-tooltips/docs-tooltips.js
@@ -1,8 +1,8 @@
 (() => {
   const Preferences = $gmedit['ui.Preferences'];
-  
+  const Project = $gmedit['gml.Project'];
+
   const state = {
-    enabled: true,
     strictLatest: false,
     keys: []
   };
@@ -15,20 +15,15 @@
       downloadLatestDocs();
 
       if (!Preferences.current.docs_tooltips) Preferences.current.docs_tooltips = {
-        enabled: true,
         strictLatest: false,
         keys: []
       };
 
-      state.enabled = Preferences.current.docs_tooltips.enabled;
       state.strictLatest = Preferences.current.docs_tooltips.strictLatest;
       state.keys = Preferences.current.docs_tooltips.keys;
 
       aceEditor.tooltipManager.ttip.setText = function() {
-        if (!state.enabled
-          || (state.strictLatest && $gmedit['gml.Project'].current.version.name != 'v23')
-          || state.keys == null
-        ) {
+        if ((state.strictLatest && !Project.current.isGMS23) || state.keys == null) {
           ogSetText.apply(this, arguments);
           return;
         }
@@ -58,12 +53,6 @@
       aceEditor.tooltipManager.ttip.setText = ogSetText;
     },
     buildPreferences: (out) => {
-    
-      Preferences.addCheckbox(out, 'Enabled', state.enabled, () => {
-        state.enabled = !state.enabled;
-        Preferences.current.docs_tooltips.enabled = state.enabled;
-        Preferences.save();
-      });
   
       Preferences.addCheckbox(out, 'Disable for non GMS2.3+ projects', state.strictLatest, () => {
         state.strictLatest = !state.strictLatest;

--- a/bin/resources/app/plugins/image-viewer/image-viewer.js
+++ b/bin/resources/app/plugins/image-viewer/image-viewer.js
@@ -37,10 +37,10 @@
 			file.editor = new ImageViewer(file);
 		}
 	});
+	var kimg = new KImage();
 	//
 	GMEdit.register("image-viewer", {
 		init: function() {
-			var kimg = new KImage();
 			FileKind.register("png", kimg);
 			FileKind.register("jpg", kimg);
 			FileKind.register("jpeg", kimg);
@@ -48,7 +48,11 @@
 			FileKind.register("bmp", kimg);
 		},
 		cleanup: function() {
-			// todo
+			FileKind.deregister("png", kimg);
+			FileKind.deregister("jpg", kimg);
+			FileKind.deregister("jpeg", kimg);
+			FileKind.deregister("gif", kimg);
+			FileKind.deregister("bmp", kimg);
 		}
 	});
 })();

--- a/bin/resources/app/plugins/image-viewer/image-viewer.js
+++ b/bin/resources/app/plugins/image-viewer/image-viewer.js
@@ -1,58 +1,65 @@
 (function() {
 	//
-	var Panner = $gmedit["editors.Panner"];
-	var Editor = $gmedit["editors.Editor"];
-	function ImageViewer(file) {
-		Editor.call(this, file);
-		this.element = document.createElement("div");
-		this.element.classList.add("resinfo");
-		this.element.classList.add("sprite");
-		//
-		var panner = null;
-		var pandiv = document.createElement("div");
-		this.element.appendChild(pandiv);
-		//
-		var image = document.createElement("img");
-		image.onload = function(_) {
-			panner.recenter();
-		};
-		pandiv.appendChild(image);
-		this.image = image;
-		//
-		panner = new Panner(pandiv, image);
-		this.panner = panner;
-	}
-	ImageViewer.prototype = GMEdit.extend(Editor.prototype, {
-		load: function(data) {
+	const Panner = $gmedit["editors.Panner"];
+	const Editor = $gmedit["editors.Editor"];
+	const FileKind = $gmedit["file.FileKind"];
+
+	class ImageViewer extends Editor {
+
+		constructor(file) {
+
+			super(file);
+			
+			this.element = document.createElement("div");
+			this.element.classList.add("resinfo");
+			this.element.classList.add("sprite");
+			//
+			var panner = null;
+			var pandiv = document.createElement("div");
+			this.element.appendChild(pandiv);
+			//
+			var image = document.createElement("img");
+			image.onload = function(_) {
+				panner.recenter();
+			};
+			pandiv.appendChild(image);
+			this.image = image;
+			//
+			panner = new Panner(pandiv, image);
+			this.panner = panner;
+			
+		}
+
+		load(_) {
 			this.image.src = this.file.path;
 		}
-	});
-	//
-	var FileKind = $gmedit["file.FileKind"];
-	function KImage() {
-		FileKind.call(this);
+
 	}
-	KImage.prototype = GMEdit.extend(FileKind.prototype, {
-		init: function(file, data) {
+
+	class KImage extends FileKind {
+
+		static inst = new KImage();
+
+		init(file, _) {
 			file.editor = new ImageViewer(file);
 		}
-	});
-	var kimg = new KImage();
-	//
+
+	}
+
 	GMEdit.register("image-viewer", {
 		init: function() {
-			FileKind.register("png", kimg);
-			FileKind.register("jpg", kimg);
-			FileKind.register("jpeg", kimg);
-			FileKind.register("gif", kimg);
-			FileKind.register("bmp", kimg);
+			FileKind.register("png", KImage.inst);
+			FileKind.register("jpg", KImage.inst);
+			FileKind.register("jpeg", KImage.inst);
+			FileKind.register("gif", KImage.inst);
+			FileKind.register("bmp", KImage.inst);
 		},
 		cleanup: function() {
-			FileKind.deregister("png", kimg);
-			FileKind.deregister("jpg", kimg);
-			FileKind.deregister("jpeg", kimg);
-			FileKind.deregister("gif", kimg);
-			FileKind.deregister("bmp", kimg);
+			FileKind.deregister("png", KImage.inst);
+			FileKind.deregister("jpg", KImage.inst);
+			FileKind.deregister("jpeg", KImage.inst);
+			FileKind.deregister("gif", KImage.inst);
+			FileKind.deregister("bmp", KImage.inst);
 		}
 	});
 })();

--- a/bin/resources/app/plugins/ini-editor/ini-editor.js
+++ b/bin/resources/app/plugins/ini-editor/ini-editor.js
@@ -150,13 +150,19 @@
 	KIni.prototype = GMEdit.extend(KCode.prototype, {
 		// we don't need to override anything if it's pure code
 	});
-	//
+	
+	var kini = new KIni();
+
 	GMEdit.register("ini-editor", {
-		init: function() {
-			var kini = new KIni();
+		init: () => {
 			FileKind.register("ini", kini);
 			FileKind.register("cfg", kini);
 			FileKind.register("conf", kini);
+		},
+		cleanup: () => {
+			FileKind.deregister("ini", kini);
+			FileKind.deregister("cfg", kini);
+			FileKind.deregister("conf", kini);
 		}
 	});
 })();

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -135,10 +135,10 @@ class Main {
 		PluginManager.initApi();
 		Project.init();
 		aceEditor.statusBar.update();
+		Project.nameNode.innerText = "Loading project...";
+		Project.openInitialProject();
 		Project.nameNode.innerText = "Loading plugins...";
 		PluginManager.loadInstalledPlugins(function() {
-			Project.nameNode.innerText = "Loading project...";
-			Project.openInitialProject();
 			#if lwedit
 			aceEditor.session = WelcomePage.init(aceEditor);
 			LiveWeb.init();

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -132,17 +132,17 @@ class Main {
 		ProjectStyle.init();
 		FileDrag.init();
 		ChromeTabs.init();
+		PluginManager.initApi();
 		Project.init();
 		aceEditor.statusBar.update();
 		Project.nameNode.innerText = "Loading plugins...";
-		plugins.PluginManager.init(function() {
+		PluginManager.loadInstalledPlugins(function() {
 			Project.nameNode.innerText = "Loading project...";
 			Project.openInitialProject();
 			#if lwedit
 			aceEditor.session = WelcomePage.init(aceEditor);
 			LiveWeb.init();
 			#end
-			PluginManager.dispatchInitCallbacks();
 		});
 		Console.log("hello!");
 		StartupTests.main();

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -138,11 +138,12 @@ class Main {
 		Project.nameNode.innerText = "Loading project...";
 		Project.openInitialProject();
 		Project.nameNode.innerText = "Loading plugins...";
-		PluginManager.loadInstalledPlugins(function() {
+		PluginManager.loadInstalledPlugins().then(function(_) {
 			#if lwedit
 			aceEditor.session = WelcomePage.init(aceEditor);
 			LiveWeb.init();
 			#end
+			PluginManager.startPlugins();
 		});
 		Console.log("hello!");
 		StartupTests.main();

--- a/src/file/FileKind.hx
+++ b/src/file/FileKind.hx
@@ -21,6 +21,12 @@ import js.html.Console;
 	public static var inst:FileKind = new FileKind();
 	/** file extension -> handlers */
 	public static var map:Dictionary<Array<FileKind>> = new Dictionary();
+
+	/**
+		Register a `FileKind` to handle files with the given extension. There may be multiple kinds
+		registered for the same extension. To disambiguate, for a file extension which may have
+		multiple content types, `FileKind.detect()` should be overridden.
+	**/
 	public static function register(fileExt:String, file:FileKind):Void {
 		var arr = map[fileExt];
 		if (arr == null) {
@@ -29,7 +35,25 @@ import js.html.Console;
 		}
 		arr.unshift(file);
 	}
-	//
+
+	/**
+		De-register a `FileKind` as a handler for the given extension. This should be called on
+		clean-up of a plugin which registers any file types.
+	**/
+	public static function deregister(fileExt:String, file:FileKind):Void {
+		
+		final arr = map[fileExt];
+
+		if (arr == null) {
+			Console.error('Tried to de-register a file kind for the extension "$fileExt", which has none registered.');
+			return;
+		}
+
+		if (!arr.remove(file)) {
+			Console.error('Tried to de-register file kind ${file.getName()} for the extension "$fileExt", of which it is not registered to.');
+		}
+
+	}
 	
 	public var checkSelfForChanges:Bool = true;
 	

--- a/src/file/FileKind.hx
+++ b/src/file/FileKind.hx
@@ -1,4 +1,5 @@
 package file;
+import ui.ChromeTabs;
 import editors.EditCode;
 import editors.Editor;
 import electron.FileSystem;
@@ -41,6 +42,12 @@ import js.html.Console;
 		clean-up of a plugin which registers any file types.
 	**/
 	public static function deregister(fileExt:String, file:FileKind):Void {
+
+		for (tab in ChromeTabs.getTabs()) {
+			if (tab.gmlFile?.kind == file) {
+				tab.closeButton.click();
+			}
+		}
 		
 		final arr = map[fileExt];
 

--- a/src/file/kind/misc/KProjectProperties.hx
+++ b/src/file/kind/misc/KProjectProperties.hx
@@ -12,7 +12,9 @@ import ui.project.ProjectProperties;
  * @author YellowAfterlife
  */
 class KProjectProperties extends KPreferencesBase {
-	public static var inst = new KProjectProperties();
+	
+	public static final inst = new KProjectProperties();
+
 	override public function init(file:GmlFile, data:Dynamic):Void {
 		file.editor = new KProjectPropertiesEditor(file, data);
 	}
@@ -23,23 +25,30 @@ class KProjectProperties extends KPreferencesBase {
 	}
 	public static function loadTabState(tabState:ProjectTabState):GmlFile {
 		if (tabState.kind != tabStateKind) return null;
-		var file = ProjectProperties.open();
+		var file = ProjectProperties.open() ?? return null;
 		file.editor.element.scrollTop = tabState.data.top;
 		return file;
 	}
 }
+
 class KProjectPropertiesEditor extends Editor {
-	public var project:Project;
+
+	public final project:Project;
+
 	public function new(file:GmlFile, pj:Project) {
+
 		super(file);
 		project = pj;
+
 		if (pj.propertiesElement == null) {
 			pj.propertiesElement = Main.document.createDivElement();
 			pj.propertiesElement.classList.add("popout-window");
 			pj.propertiesElement.classList.add("project-properties");
 			ProjectProperties.build(pj, pj.propertiesElement);
 		}
+
 		element = pj.propertiesElement;
+
 		/*if (el == null) {
 			el = Main.document.createDivElement();
 			el.classList.add("popout-window");

--- a/src/gml/Project.hx
+++ b/src/gml/Project.hx
@@ -593,7 +593,7 @@ import ui.treeview.TreeViewElement;
 				} else electron.IPC.send("set-taskbar-icon", null, "");
 			} catch (x:Dynamic) {}
 			
-			if (PluginManager.ready == true && version != GmlVersion.none) {
+			if (version != GmlVersion.none) {
 				PluginEvents.projectOpen({project:this});
 			}
 			ui.ProjectStyle.reload();

--- a/src/plugins/PluginAPI.hx
+++ b/src/plugins/PluginAPI.hx
@@ -26,14 +26,14 @@ class PluginAPI {
 	 * Registers a plugin in GMEdit.
 	 * This must be called by your plugin's script.
 	 */
-	public static function register(pluginName:PluginRegName, data:PluginData) {
-		final state = PluginManager.registry[pluginName];
+	public static function register(name:PluginRegName, data:PluginData) {
 		
-		if (state == null) {
-			throw 'There\'s no plugin named $pluginName';
+		final error = PluginManager.register(name, data);
+
+		if (error != null) {
+			throw error;
 		}
 
-		state.data = data;
 	}
 	
 	// The following just point to specific classes for convenience

--- a/src/plugins/PluginAPI.hx
+++ b/src/plugins/PluginAPI.hx
@@ -1,4 +1,5 @@
 package plugins;
+import plugins.PluginConfig.PluginRegName;
 import haxe.DynamicAccess;
 import ui.Sidebar;
 import ace.AceTools;
@@ -25,9 +26,9 @@ class PluginAPI {
 	 * Registers a plugin in GMEdit.
 	 * This must be called by your plugin's script.
 	 */
-	public static function register(pluginName:String, data:PluginData) {
-		var state = PluginManager.registerMap[pluginName];
-		if (state == null) throw "There's no plugin named " + pluginName;
+	public static function register(pluginName:PluginRegName, data:PluginData) {
+		var state = PluginManager.registry[pluginName];
+		if (state == null) throw 'There\'s no plugin named $pluginName';
 		state.data = data;
 	}
 	

--- a/src/plugins/PluginAPI.hx
+++ b/src/plugins/PluginAPI.hx
@@ -27,8 +27,12 @@ class PluginAPI {
 	 * This must be called by your plugin's script.
 	 */
 	public static function register(pluginName:PluginRegName, data:PluginData) {
-		var state = PluginManager.registry[pluginName];
-		if (state == null) throw 'There\'s no plugin named $pluginName';
+		final state = PluginManager.registry[pluginName];
+		
+		if (state == null) {
+			throw 'There\'s no plugin named $pluginName';
+		}
+
 		state.data = data;
 	}
 	

--- a/src/plugins/PluginConfig.hx
+++ b/src/plugins/PluginConfig.hx
@@ -1,9 +1,12 @@
 package plugins;
 
 /**
- * ...
- * @author YellowAfterlife
- */
+	The configuration data from `config.json` of a plugin. Holds the registry name of the plugin,
+	which should always be preferred over the dir name if available, along with the list of resource
+	names and dependencies of the plugin.
+
+	@author YellowAfterLife
+**/
 typedef PluginConfig = {
 	
 	/** One of the scripts then should do GMEdit.register(name, {...}) */
@@ -12,8 +15,8 @@ typedef PluginConfig = {
 	/** Optional - shows in Preferences */
 	?description:String,
 	
-	/** Relative paths to .js files (if any) */
-	?scripts:Array<String>,
+	/** Relative paths to .js files */
+	scripts:Array<String>,
 	
 	/** relative paths to .css files(if any) */
 	?stylesheets:Array<String>,

--- a/src/plugins/PluginConfig.hx
+++ b/src/plugins/PluginConfig.hx
@@ -7,7 +7,7 @@ package plugins;
 typedef PluginConfig = {
 	
 	/** One of the scripts then should do GMEdit.register(name, {...}) */
-	name:String,
+	name:PluginRegName,
 	
 	/** Optional - shows in Preferences */
 	?description:String,
@@ -18,6 +18,21 @@ typedef PluginConfig = {
 	/** relative paths to .css files(if any) */
 	?stylesheets:Array<String>,
 	
-	/** Plugins that should be loaded before this one can be loaded */
-	?dependencies:Array<String>,
+	/** 
+		Plugins that should be initialised before this plugin.
+	**/
+	?dependencies:Array<PluginRegName>,
 };
+
+/**
+	Name of a given plugin in the plugin registry. This name is derived from a plugin's
+	`config.json`, and is the name used for `GMEdit.register(...)`.
+**/
+abstract PluginRegName(String) to String {}
+
+/**
+	Name of a given plugin's directory. We cannot know what a plugin's registry name
+	is until the plugin's config has been loaded, so this is another unique identifier which is used
+	to then derive the registry name.
+**/
+abstract PluginDirName(String) from String to String {}

--- a/src/plugins/PluginData.hx
+++ b/src/plugins/PluginData.hx
@@ -1,5 +1,6 @@
 package plugins;
 
+import gml.Project;
 import js.html.Element;
 
 /**
@@ -30,4 +31,19 @@ typedef PluginData = {
 		build their preferences list when the plugin is reloaded in-place.
 	**/
 	?buildPreferences:(element:Element)->Void,
+
+	/**
+		Called to build out the project properties for this plugin, in its respective group, just
+		like the above `buildPreferences`.
+
+		This method is, equally, preferable over `PluginEvents.projectPropertiesBuilt`, for the same
+		reasons.
+
+		Unlike the mentioned event, this method matches the preferences menu by providing a group
+		for the plugin implicitly, if the plugin implements this method.
+
+		@param element The body of the group element belonging to this plugin.
+		@param project The project for which this properties menu is for.
+	**/
+	?buildProjectProperties:(element:Element, project:Project)->Void,
 }

--- a/src/plugins/PluginData.hx
+++ b/src/plugins/PluginData.hx
@@ -1,7 +1,11 @@
 package plugins;
 
+import js.html.Element;
+
 /**
- * ...
+ * Registration data for a given plugin, provided by calling `GMEdit.register(name, {...})`.
+ * Should ideally implement `init` and `cleanup` at least.
+ * 
  * @author YellowAfterlife
  */
 typedef PluginData = {
@@ -15,4 +19,15 @@ typedef PluginData = {
 	 * set up.
 	 */
 	?cleanup:()->Void,
+
+	/**
+		Called to build out the preferences list for this plugin in its respective group in the
+		preferences menu.
+
+		Implementing this method is preferable over `PluginEvents.preferencesBuilt`, which fires
+		only when the entire preferences menu is being constructed, and plugins are forced to
+		locate their respective elements manually, and does not give plugins an opportunity to
+		build their preferences list when the plugin is reloaded in-place.
+	**/
+	?buildPreferences:(element:Element)->Void,
 }

--- a/src/plugins/PluginData.hx
+++ b/src/plugins/PluginData.hx
@@ -11,7 +11,8 @@ typedef PluginData = {
 	?init:(state:PluginState)->Void,
 	
 	/**
-	 * Called before unloading the plugin (currently you cannot)
+	 * Called to unload the plugin. This is the plugin's opportunity to de-register anything it has
+	 * set up.
 	 */
 	?cleanup:()->Void,
 }

--- a/src/plugins/PluginEvents.hx
+++ b/src/plugins/PluginEvents.hx
@@ -88,9 +88,12 @@ extern class PluginEvents {
 	 * Called after constructing the preferences menu.
 	 * You can use this to insert your plugin-specific DOM elements into it.
 	 * ui.Preferences offers a large set of helpers for all kinds of helpers.
+	 * 
+	 * @deprecated Consider implementing `PluginData.buildPreferences` instead, which doesn't
+	 *             require manual location of the plugin's preferences element, and fires on reloads.
 	 */
 	static function preferencesBuilt(e:{target:Element}):Void;
-	
+
 	/**
 	 * Called after constructing the preferences menu.
 	 * You can use this to insert your plugin-specific DOM elements into it.

--- a/src/plugins/PluginEvents.hx
+++ b/src/plugins/PluginEvents.hx
@@ -98,6 +98,9 @@ extern class PluginEvents {
 	 * Called after constructing the preferences menu.
 	 * You can use this to insert your plugin-specific DOM elements into it.
 	 * ui.Preferences is similarly used here.
+	 * 
+	 * @deprecated Consider implementing `PluginData.buildProjectProperties` instead, for similar
+	 * 			   reasons to that stated above.
 	 */
 	static function projectPropertiesBuilt(e:{project:Project, target:Element}):Void;
 	

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -125,7 +125,7 @@ class PluginManager {
 		
 		return Promise.all(skeletonPromises)
 			.then(function(plugins) {
-				final validPlugins = plugins.filter(function(plugin) return plugin.error == null);
+				final validPlugins = plugins.filter(plugin -> plugin.error == null);
 				return Promise.all(validPlugins.map(load));
 			})
 			.then(_ -> null);

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -210,7 +210,7 @@ class PluginManager {
 				final link = Main.document.createLinkElement();
 				link.setAttribute("data-plugin", plugin.config.name);
 				link.rel = "stylesheet";
-				link.href = '${plugin.path}/$styleName';
+				link.href = '${plugin.dir}/$styleName';
 
 				plugin.styles.push(link);
 
@@ -224,7 +224,7 @@ class PluginManager {
 		var nextScriptName = scriptsToLoad.shift();
 
 		function loadNextScript(): Promise<Null<Error>> {
-			return loadScript('${plugin.path}/$nextScriptName').then(function(result) {
+			return loadScript('${plugin.dir}/$nextScriptName').then(function(result) {
 
 				final script = switch (result) {
 					case Ok(data): data;
@@ -307,7 +307,7 @@ class PluginManager {
 		plugin.error = null;
 		plugin.data = null;
 
-		return loadConfig(plugin.path, plugin.name)
+		return loadConfig(plugin.dir, plugin.name)
 			.then(function(result) {
 
 				final config = switch (result) {

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -173,7 +173,7 @@ class PluginManager {
 		) {
 
 			if (error != null) {
-				return res(Err(ConfigLoadError.NoSuchFile(configPath)));
+				return res(Err(ConfigLoadError.IOError(configPath, error)));
 			}
 			
 			if (config.name == null) {
@@ -552,13 +552,13 @@ class PluginManager {
 	An error encountered whilst attempting to load a plugin's configuration file.
 **/
 private enum ConfigLoadError {
-	NoSuchFile(path:String);
+	IOError(path:String, error:Error);
 	InvalidSchema(info:String);
 }
 
 private class ConfigLoadErrorMethods {
 	public static inline function toJsError(error:ConfigLoadError): Error return switch (error) {
-		case NoSuchFile(path): new Error('"$path" does not exist');
+		case IOError(path, error): new Error('IO error reading from "$path": $error');
 		case InvalidSchema(info): new Error('config.json is invalid: $info');
 	};
 }

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -203,7 +203,7 @@ class PluginManager {
 	public static function dispatchInitCallbacks() {
 		for (pluginName in pluginList) {
 
-			if (isDisabledByUser(pluginName)) {
+			if (!isEnabled(pluginName)) {
 				continue;
 			}
 
@@ -284,10 +284,10 @@ class PluginManager {
 	}
 
 	/**
-		Returns whether the given plugin has been disabled by the user.
+		Returns whether the given plugin is enabled, as the user may disable plugins.
 	**/
-	public static function isDisabledByUser(pluginName:String): Bool {
-		return Preferences.current.disabledPlugins.contains(pluginName);
+	public static function isEnabled(pluginName:String): Bool {
+		return !Preferences.current.disabledPlugins.contains(pluginName);
 	}
 
 	/**

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -12,9 +12,9 @@ import js.html.ErrorEvent;
 import plugins.PluginAPI;
 import plugins.PluginConfig;
 import plugins.PluginState;
+import tools.Dictionary;
 using plugins.PluginManager.ConfigLoadErrorMethods;
 using tools.ArrayTools;
-using StringTools;
 
 /**
  * ...
@@ -257,7 +257,9 @@ class PluginManager {
 
 			if (error != null) {
 				plugin.error = error;
-			} else if (plugin.data == null) {
+			}
+			
+			if (plugin.data == null) {
 				plugin.error = new Error("Plugin finished loading but did not call `GMEdit.register(...)`");
 			}
 
@@ -283,24 +285,17 @@ class PluginManager {
 		return new Promise(function(res, _) {
 
 			final script = Main.document.createScriptElement();
-
-			function errorEventListener(event:ErrorEvent) {
-				if (event.filename.endsWith(path)) {
-					Main.window.removeEventListener("error", errorEventListener);
-					script.onload = null;
-					
-					return res(Err(event.error));
-				}
-			}
-
-			Main.window.addEventListener("error", errorEventListener);
 			
 			script.onload = function() {
-				
-				Main.window.removeEventListener("error", errorEventListener);
 				script.onload = null;
-				
+				script.onerror = null;
 				return res(Ok(script));
+			};
+
+			script.onerror = function(e) {
+				script.onload = null;
+				script.onerror = null;
+				return res(Err(e));
 			};
 				
 			script.src = path;

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -277,8 +277,19 @@ class PluginManager {
 		return new Promise(function(res, _) {
 
 			final script = Main.document.createScriptElement();
-			script.onload = function() return res(Ok(script));
-			script.onerror = function(e) return res(Err(e));
+			
+			script.onload = function() {
+				script.onload = null;
+				script.onerror = null;
+				return res(Ok(script));
+			};
+
+			script.onerror = function(e) {
+				script.onload = null;
+				script.onerror = null;
+				return res(Err(e));
+			};
+				
 			script.src = path;
 
 			Main.document.head.appendChild(script);

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -206,7 +206,11 @@ class PluginManager {
 	**/
 	static function load(plugin:PluginState): Promise<Null<Error>> {
 
-		registry[plugin.config.name] ??= plugin;
+		if (registry[plugin.config.name] != null) {
+			return Promise.resolve(new Error('Registry name "${plugin.config.name}" is already in use and cannot be re-registered!'));
+		}
+
+		registry[plugin.config.name] = plugin;
 
 		// We can just let styles load up asynchronously.
 		if (plugin.config.stylesheets != null) {
@@ -324,6 +328,8 @@ class PluginManager {
 		plugin.styles.resize(0);
 		plugin.error = null;
 		plugin.data = null;
+
+		registry[plugin.config.name] = null;
 
 		return loadConfig(plugin.dir, plugin.name)
 			.then(function(result) {

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -213,6 +213,28 @@ class PluginManager {
 	}
 
 	/**
+		Reload the given plugin. If the plugin is enabled, it will be initialised immediately.
+	**/
+	public static function reload(pluginName:String, onLoad:PluginState -> Void) {
+
+		stop(pluginName);
+
+		final registeredName = pluginMap[pluginName]?.config?.name;
+
+		if (registeredName != null) {
+			registerMap.remove(registeredName);
+		}
+		
+		pluginMap.remove(pluginName);
+
+		load(pluginName, function(_) {
+			start(pluginName);
+			onLoad(pluginMap[pluginName]);
+		});
+
+	}
+
+	/**
 		Start the given registered plugin.
 	**/
 	public static function start(pluginName:String): Null<Error> {

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -165,15 +165,15 @@ class PluginManager {
 		) {
 
 			if (error != null) {
-				return res(Err(ConfigLoadError.NoSuchFile(name, configPath)));
+				return res(Err(ConfigLoadError.NoSuchFile(configPath)));
 			}
 			
 			if (config.name == null) {
-				return res(Err(ConfigLoadError.InvalidSchema(name, "Config does not specify plugin's registry name")));
+				return res(Err(ConfigLoadError.InvalidSchema("Config does not specify plugin's registry name")));
 			}
 			
 			if (config.scripts == null) {
-				return res(Err(ConfigLoadError.InvalidSchema(name, "Config does not specify any scripts, plugin cannot register if it has no content")));
+				return res(Err(ConfigLoadError.InvalidSchema("Config does not specify any scripts, plugin cannot register if it has no content")));
 			}
 
 			return res(Ok(config));
@@ -526,13 +526,13 @@ class PluginManager {
 	An error encountered whilst attempting to load a plugin's configuration file.
 **/
 private enum ConfigLoadError {
-	NoSuchFile(pluginName:PluginDirName, path:String);
-	InvalidSchema(pluginName:PluginDirName, info:String);
+	NoSuchFile(path:String);
+	InvalidSchema(info:String);
 }
 
 private class ConfigLoadErrorMethods {
 	public static inline function toJsError(error:ConfigLoadError): Error return switch (error) {
-		case NoSuchFile(pluginName, path): new Error('$pluginName\'s config.json ("$path") does not exist');
-		case InvalidSchema(pluginName, info): new Error('$pluginName\'s config.json is invalid: $info');
+		case NoSuchFile(path): new Error('"$path" does not exist');
+		case InvalidSchema(info): new Error('config.json is invalid: $info');
 	};
 }

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -26,6 +26,13 @@ class PluginManager {
 	public static var registry:Map<PluginRegName, PluginState> = new Map();
 
 	/**
+		List of known plugins, registered or not. Used to keep track of plugins for which loading
+		their configuration failed, so we can still show them in the UI, for instance for a plugin
+		dev to be able to attempt to reload immediately rather than reloading GMEdit entirely.
+	**/
+	public static final knownPlugins:Array<PluginState> = [];
+
+	/**
 		Initialise the plugins API. Until this method has been executed, `PluginAPI` cannot be used,
 		and plugins should not be initialised as they will not be able to access events.
 	**/
@@ -100,6 +107,7 @@ class PluginManager {
 
 				final path = '$dirPath/$name';
 				final plugin = new PluginState(name, path);
+				knownPlugins.push(plugin);
 
 				skeletonPromises.push(loadConfig(path, name).then(function(result) {
 					

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -96,6 +96,7 @@ class PluginManager {
 				#end
 				"gen-enum-names",
 				"show-aside",
+				"docs-tooltips"
 			];
 
 		}

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -85,7 +85,7 @@ class PluginManager {
 								state.finish(e.error);
 							};
 							script.src = '$dir/$name/$rel' + suffix;
-							state.elements.push(script);
+							state.scripts.push(script);
 							Main.document.head.appendChild(script);
 						};
 						case 1: {
@@ -101,7 +101,7 @@ class PluginManager {
 							}
 							style.rel = "stylesheet";
 							style.href = '$dir/$name/$rel' + suffix;
-							state.elements.push(style);
+							state.styles.push(style);
 							Main.document.head.appendChild(style);
 						};
 					}
@@ -219,7 +219,17 @@ class PluginManager {
 
 		stop(pluginName);
 
-		final registeredName = pluginMap[pluginName]?.config?.name;
+		final pluginState = pluginMap[pluginName];
+
+		for (script in pluginState.scripts) {
+			script.remove();
+		}
+
+		for (style in pluginState.styles) {
+			style.remove();
+		}
+
+		final registeredName = pluginState.config?.name;
 
 		if (registeredName != null) {
 			registerMap.remove(registeredName);
@@ -247,6 +257,10 @@ class PluginManager {
 		if (pluginState.data.init != null) {
 			pluginState.data.init(pluginState);
 		}
+
+		for (style in pluginState.styles) {
+			style.disabled = false;
+		}
 		
 		return null;
 	}
@@ -263,8 +277,8 @@ class PluginManager {
 			pluginState.data.cleanup();
 		}
 
-		for (el in pluginState.elements) {
-			el.remove();
+		for (style in pluginState.styles) {
+			style.disabled = true;
 		}
 		
 	}

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -207,7 +207,8 @@ class PluginManager {
 	static function load(plugin:PluginState): Promise<Null<Error>> {
 
 		if (registry[plugin.config.name] != null) {
-			return Promise.resolve(new Error('Registry name "${plugin.config.name}" is already in use and cannot be re-registered!'));
+			plugin.error = new Error('Registry name "${plugin.config.name}" is already in use and cannot be re-registered!');
+			return Promise.resolve(plugin.error);
 		}
 
 		registry[plugin.config.name] = plugin;

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -330,7 +330,10 @@ class PluginManager {
 		plugin.error = null;
 		plugin.data = null;
 
-		registry[plugin.config.name] = null;
+		// Duplicate plugin names shouldn't de-reg the first plugin.
+		if (isRegistered(plugin)) {
+			registry[plugin.config.name] = null;
+		}
 
 		return loadConfig(plugin.dir, plugin.name)
 			.then(function(result) {
@@ -549,6 +552,14 @@ class PluginManager {
 
 		plugin.syncPrefs();
 
+	}
+
+	/**
+		Returns whether the given plugin is registered. Plugins are not registered in the case that
+		their name is already taken, or that their config is missing or invalid.
+	**/
+	static inline function isRegistered(plugin:PluginState):Bool {
+		return (plugin.config != null) && (registry[plugin.config.name] == plugin);
 	}
 
 }

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -128,7 +128,7 @@ class PluginManager {
 				final validPlugins = plugins.filter(function(plugin) return plugin.error == null);
 				return Promise.all(validPlugins.map(load));
 			})
-			.then(function(plugins) {});
+			.then(_ -> null);
 		
 	}
 	

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -17,12 +17,19 @@ using plugins.PluginManager.ConfigLoadErrorMethods;
 using tools.ArrayTools;
 
 /**
- * ...
- * @author YellowAfterlife
- */
+	Singleton that manages loading and running of plugins. This class should **never** be directly
+	interacted with by plugins.
+
+	@see https://github.com/YellowAfterlife/GMEdit/wiki/Using-plugins
+	@author YellowAfterlife
+**/
 class PluginManager {
 
-	/** name from `config.json` -> state */
+	/**
+		Plugins register themselves by a name specified in their configuration file. This is a
+		unique identifier for that plugin, and the manager uses this to differentiate plugins when
+		they call `GMEdit.register(...)` with their methods struct, and to resolve dependencies.
+	**/
 	public static var registry:Map<PluginRegName, PluginState> = new Map();
 
 	/**

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -17,8 +17,6 @@ import tools.Dictionary;
  */
 class PluginManager {
 
-	/** name from `config.json` */
-	public static var pluginList:Array<PluginRegName> = [];
 	/** name -> state */
 	public static var pluginMap:Map<PluginDirName, PluginState> = new Map();
 	/** name -> containing directory */
@@ -220,7 +218,7 @@ class PluginManager {
 		Start the loaded and enabled plugins.
 	**/
 	static function startEnabledPlugins() {
-		for (name in pluginList) {
+		for (name => _ in registry) {
 
 			if (!isEnabled(name)) {
 				continue;
@@ -400,20 +398,18 @@ class PluginManager {
 	**/
 	static function getDependents(name:PluginRegName): Array<PluginState> {
 
-		final plugin = registry[name];
-		final pluginRegName = plugin.config.name;
 		final dependents: Array<PluginState> = [];
 
-		for (regName in pluginList) {
+		for (depName => _ in registry) {
 			
-			if (regName == pluginRegName) {
+			if (depName == name) {
 				continue;
 			}
 
-			final maybeDependent = registry[regName] ?? continue;
+			final maybeDependent = registry[depName] ?? continue;
 			final dependencies = maybeDependent.config.dependencies ?? continue;
 
-			if (dependencies.contains(pluginRegName)) {
+			if (dependencies.contains(name)) {
 				dependents.push(maybeDependent);
 			}
 

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -349,7 +349,7 @@ class PluginManager {
 				start(plugin, true);
 
 				final dependentPromises = getDependents(plugin.config.name).map(reload);
-				return Promise.all(dependentPromises).then(function(_) {});
+				return Promise.all(dependentPromises).then(_ -> null);
 
 			});
 

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -202,9 +202,6 @@ class PluginManager {
 		If all scripts have executed, but the plugin has *not* been registered, the plugin is
 		considered to have failed to load.
 
-		If any of the scripts included in the plugin fail to execute, the plugin is also considered
-		to have failed to load.
-
 		@param plugin The uninitialised plugin to be loaded.
 	**/
 	static function load(plugin:PluginState): Promise<Null<Error>> {

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -244,7 +244,7 @@ class PluginManager {
 			return pluginState.error;
 		}
 
-		if (pluginState.data?.init != null) {
+		if (pluginState.data.init != null) {
 			pluginState.data.init(pluginState);
 		}
 		

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -12,9 +12,9 @@ import js.html.ErrorEvent;
 import plugins.PluginAPI;
 import plugins.PluginConfig;
 import plugins.PluginState;
-import tools.Dictionary;
 using plugins.PluginManager.ConfigLoadErrorMethods;
 using tools.ArrayTools;
+using StringTools;
 
 /**
  * ...
@@ -257,9 +257,7 @@ class PluginManager {
 
 			if (error != null) {
 				plugin.error = error;
-			}
-			
-			if (plugin.data == null) {
+			} else if (plugin.data == null) {
 				plugin.error = new Error("Plugin finished loading but did not call `GMEdit.register(...)`");
 			}
 
@@ -285,17 +283,24 @@ class PluginManager {
 		return new Promise(function(res, _) {
 
 			final script = Main.document.createScriptElement();
+
+			function errorEventListener(event:ErrorEvent) {
+				if (event.filename.endsWith(path)) {
+					Main.window.removeEventListener("error", errorEventListener);
+					script.onload = null;
+					
+					return res(Err(event.error));
+				}
+			}
+
+			Main.window.addEventListener("error", errorEventListener);
 			
 			script.onload = function() {
+				
+				Main.window.removeEventListener("error", errorEventListener);
 				script.onload = null;
-				script.onerror = null;
+				
 				return res(Ok(script));
-			};
-
-			script.onerror = function(e) {
-				script.onload = null;
-				script.onerror = null;
-				return res(Err(e));
 			};
 				
 			script.src = path;

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -26,18 +26,18 @@ using tools.ArrayTools;
 class PluginManager {
 
 	/**
-		Plugins register themselves by a name specified in their configuration file. This is a
-		unique identifier for that plugin, and the manager uses this to differentiate plugins when
-		they call `GMEdit.register(...)` with their methods struct, and to resolve dependencies.
-	**/
-	public static var registry:Map<PluginRegName, PluginState> = new Map();
-
-	/**
 		List of known plugins, registered or not. Used to keep track of plugins for which loading
 		their configuration failed, so we can still show them in the UI, for instance for a plugin
 		dev to be able to attempt to reload immediately rather than reloading GMEdit entirely.
 	**/
 	public static final knownPlugins:Array<PluginState> = [];
+
+	/**
+		Plugins register themselves by a name specified in their configuration file. This is a
+		unique identifier for that plugin, and the manager uses this to differentiate plugins when
+		they call `GMEdit.register(...)` with their methods struct, and to resolve dependencies.
+	**/
+	static final registry:Map<PluginRegName, PluginState> = new Map();
 
 	/**
 		Initialise the plugins API. Until this method has been executed, `PluginAPI` cannot be used,
@@ -281,6 +281,22 @@ class PluginManager {
 			return null;
 
 		});
+
+	}
+	
+	/**
+		Register the plugin with the given name in the registry.
+	**/
+	public static function register(name:PluginRegName, data:PluginData):Null<Error> {
+
+		final plugin = registry[name] ?? return new Error('There\'s no plugin named $name');
+
+		if (plugin.data != null) {
+			return new Error('Cannot register previously-registered plugin $name');
+		}
+
+		plugin.data = data;
+		return null;
 
 	}
 

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -333,6 +333,7 @@ class PluginManager {
 					case Err(err): return Promise.resolve(err.toJsError());
 				}
 
+				plugin.config = config;
 				return load(plugin);
 
 			})

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -71,9 +71,7 @@ class PluginState {
 			canCleanUp = false;
 		} else Console.log("Plugin loaded: " + name);
 
-		if (PluginManager.pluginList.indexOf(config.name) < 0) {
-			PluginManager.pluginList.push(config.name);
-		}
+		PluginManager.registry[config.name] = this;
 		
 		this.error = error;
 		for (fn in listeners) fn(error);

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -1,4 +1,5 @@
 package plugins;
+import ui.preferences.PrefPlugins.PluginPrefItem;
 import js.html.LinkElement;
 import js.html.StyleElement;
 import js.html.ScriptElement;
@@ -27,38 +28,66 @@ class PluginState {
 	public var error:Error = null;
 	public var listeners:Array<PluginCallback> = [];
 	public var data:PluginData = null;
+
+	/**
+		Whether this plugin registered a `cleanup()` handler. Plugins that cannot clean up cannot be
+		stopped at runtime and require a restart to take effect.
+
+		Plugins which fail to initialise correctly are also assumed to be incapable of cleaning up.
+	**/
+	public var canCleanUp(default, null):Bool = false;
+
+	/**
+		The preferences item associated with this plugin.
+		TODO: this is some binding that I'm not a big fan of.
+	**/
+	public var prefItem(null, default):Null<PluginPrefItem>;
+
+	/**
+		Whether this plugin has been started (`init()` has been called.)
+	**/
+	public var initialised:Bool = false;
 	
 	public var styles:Array<LinkElement> = [];
 	public var scripts:Array<ScriptElement> = [];
 	
-	//
 	public function new(name:String, dir:String) {
 		this.name = name;
 		this.dir = dir;
 	}
 
 	public function finish(?error:Error):Void {
+		
 		ready = true;
-		if (error == null && data == null) {
-			error = new Error('Plugin did not call register()');
+
+		if (data != null) {
+			canCleanUp = (data.cleanup != null);
+		} else if (error == null) {
+			error = new Error("Plugin did not call register()");
 		}
+
 		if (error != null) {
 			Console.error('Plugin load failed for $name:', error);
+			canCleanUp = false;
 		} else Console.log("Plugin loaded: " + name);
 		if (PluginManager.pluginList.indexOf(name) < 0) {
 			PluginManager.pluginList.push(name);
 		}
-		//
+		
 		this.error = error;
 		for (fn in listeners) fn(error);
 		listeners.resize(0);
-		// moved to PluginManager.dispatchInitCallbacks
-		/*if (error == null && data.init != null) {
-			var t = Date.now().getTime();
-			data.init(this);
-			var dt = Date.now().getTime() - t;
-			if (dt > 500) Console.warn('init() for $name took ${dt}ms.');
-		}*/
 	}
+
+	/**
+		Re-sync state of the associated preferences item, if one exists.
+	**/
+	public inline function syncPrefs() {
+		if (prefItem != null) {
+			prefItem.sync();
+		}
+	}
+
 }
+
 typedef PluginCallback = (error:Null<Error>)->Void;

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -33,15 +33,7 @@ class PluginState {
 		this.name = name;
 		this.dir = dir;
 	}
-	public function destroy() {
-		if (data != null && data.cleanup != null) data.cleanup();
-		for (el in elements) {
-			var p = el.parentElement;
-			if (p != null) p.removeChild(el);
-		}
-		PluginManager.pluginMap.remove(name);
-		PluginManager.registerMap.remove(config.name);
-	}
+
 	public function finish(?error:Error):Void {
 		ready = true;
 		if (error == null && data == null) {

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -21,13 +21,13 @@ import tools.Dictionary;
  * @author YellowAfterlife
  */
 class PluginState {
-	public var name:String;
+	public var name:PluginDirName;
 	public var config:PluginConfig;
 	public var dir:String;
 	public var ready:Bool = false;
-	public var error:Error = null;
+	public var error:Null<Error> = null;
 	public var listeners:Array<PluginCallback> = [];
-	public var data:PluginData = null;
+	public var data:Null<PluginData> = null;
 
 	/**
 		Whether this plugin registered a `cleanup()` handler. Plugins that cannot clean up cannot be
@@ -70,8 +70,9 @@ class PluginState {
 			Console.error('Plugin load failed for $name:', error);
 			canCleanUp = false;
 		} else Console.log("Plugin loaded: " + name);
-		if (PluginManager.pluginList.indexOf(name) < 0) {
-			PluginManager.pluginList.push(name);
+
+		if (PluginManager.pluginList.indexOf(config.name) < 0) {
+			PluginManager.pluginList.push(config.name);
 		}
 		
 		this.error = error;

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -20,7 +20,7 @@ class PluginState {
 	/**
 		The path to this plugin's directory.
 	**/
-	public final path:String;
+	public final dir:String;
 
 	/**
 		The configuration file of this plugin.
@@ -61,7 +61,7 @@ class PluginState {
 	
 	public function new(name:String, dir:String) {
 		this.name = name;
-		this.path = dir;
+		this.dir = dir;
 	}
 
 	/**

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -78,5 +78,3 @@ class PluginState {
 		return error = value;
 	}
 }
-
-typedef PluginCallback = (error:Null<Error>)->Void;

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -1,4 +1,7 @@
 package plugins;
+import js.html.LinkElement;
+import js.html.StyleElement;
+import js.html.ScriptElement;
 import ace.AceWrap;
 import electron.FileSystem;
 import electron.FileWrap;
@@ -25,8 +28,8 @@ class PluginState {
 	public var listeners:Array<PluginCallback> = [];
 	public var data:PluginData = null;
 	
-	/** Scripts and styles */
-	public var elements:Array<Element> = [];
+	public var styles:Array<LinkElement> = [];
+	public var scripts:Array<ScriptElement> = [];
 	
 	//
 	public function new(name:String, dir:String) {

--- a/src/plugins/PluginState.hx
+++ b/src/plugins/PluginState.hx
@@ -1,5 +1,5 @@
 package plugins;
-import ui.preferences.PrefPlugins.PluginPrefItem;
+import ui.preferences.PrefPlugins;
 import js.html.LinkElement;
 import js.html.ScriptElement;
 import js.html.Console;
@@ -46,12 +46,6 @@ class PluginState {
 	public var canCleanUp(get, never):Bool;
 
 	/**
-		The preferences item associated with this plugin.
-		TODO: this is some binding that I'm not a big fan of.
-	**/
-	public var prefItem(null, default):Null<PluginPrefItem>;
-
-	/**
 		Whether this plugin has been started (`init()` has been called.)
 	**/
 	public var initialised:Bool = false;
@@ -65,12 +59,10 @@ class PluginState {
 	}
 
 	/**
-		Re-sync state of the associated preferences item, if one exists.
+		Re-sync state of the associated preferences items, if they exist.
 	**/
 	public inline function syncPrefs() {
-		if (prefItem != null) {
-			prefItem.sync();
-		}
+		PrefPlugins.sync(this);
 	}
 
 	function get_canCleanUp():Bool {

--- a/src/tools/ArrayTools.hx
+++ b/src/tools/ArrayTools.hx
@@ -1,0 +1,18 @@
+package tools;
+
+/**
+	Extra utilities for working with arrays.
+**/
+class ArrayUtils {
+
+	/**
+		Return a new, flattened array based on the result of the callback function.
+	**/
+	public static inline function flatMap<T, R>(
+		array:Array<T>,
+		callbackFn:T -> Array<R>
+	): Array<R> {
+		return Reflect.callMethod(array, Reflect.field(array, "flatMap"), [callbackFn]);
+	}
+
+}

--- a/src/tools/ArrayTools.hx
+++ b/src/tools/ArrayTools.hx
@@ -11,8 +11,6 @@ class ArrayTools {
 	public static inline function flatMap<T, R>(
 		array:Array<T>,
 		callbackFn:T -> Array<R>
-	): Array<R> {
-		return Reflect.callMethod(array, Reflect.field(array, "flatMap"), [callbackFn]);
-	}
+	): Array<R> return (cast array).flatMap(callbackFn);
 
 }

--- a/src/tools/ArrayTools.hx
+++ b/src/tools/ArrayTools.hx
@@ -3,7 +3,7 @@ package tools;
 /**
 	Extra utilities for working with arrays.
 **/
-class ArrayUtils {
+class ArrayTools {
 
 	/**
 		Return a new, flattened array based on the result of the callback function.

--- a/src/tools/HtmlTools.hx
+++ b/src/tools/HtmlTools.hx
@@ -54,6 +54,16 @@ class HtmlTools {
 	public static function setDisplayFlag(el:Element, visible:Bool):Void {
 		el.style.display = visible ? "" : "none";
 	}
+	/**
+		Set whether the given group is collapsed or expanded.
+	**/
+	public static function setGroupVisibility(el:FieldSetElement, visible:Bool) {
+		if (visible) {
+			el.classList.remove("collapsed");
+		} else {
+			el.classList.add("collapsed");
+		}
+	}
 	public static function setDatasetValue(el:Element, key:String, value:String) {
 		var dataset:DynamicAccess<String> = cast el.dataset;
 		if (value == null) {

--- a/src/tools/Result.hx
+++ b/src/tools/Result.hx
@@ -1,0 +1,9 @@
+package tools;
+
+/**
+	Generic result type which may hold either desired data or an error.
+**/
+enum Result<T, E> {
+	Ok(data:T);
+	Err(err:E);
+}

--- a/src/ui/Preferences.hx
+++ b/src/ui/Preferences.hx
@@ -1,4 +1,5 @@
 package ui;
+import plugins.PluginManager;
 import haxe.extern.EitherType;
 #if !starter
 import ace.AceWrap;

--- a/src/ui/Preferences.hx
+++ b/src/ui/Preferences.hx
@@ -88,15 +88,25 @@ class Preferences {
 		lg.prepend(cb);*/
 	}
 	public static function addGroup(out:Element, legend:String):FieldSetElement {
-		var fs = document.createFieldSetElement();
-		fs.classList.add("group");
-		var lg = document.createLegendElement();
-		lg.appendChild(document.createTextNode(legend));
-		fs.appendChild(lg);
-		addGroupToggle(fs);
-		out.appendChild(fs);
-		return fs;
+		final group = createGroup(legend);
+		out.appendChild(group);
+
+		return group;
 	}
+
+	public static function createGroup(name:String):FieldSetElement {
+		final group = document.createFieldSetElement();
+		group.classList.add("group");
+		
+		final legend = document.createLegendElement();
+		legend.appendChild(document.createTextNode(name));
+		group.appendChild(legend);
+
+		addGroupToggle(group);
+
+		return group;
+	}
+
 	public static function addRadios(out:Element, legend:String, curr:String, names:Array<String>, fn:String->Void) {
 		var fs = document.createFieldSetElement();
 		fs.classList.add("radios");

--- a/src/ui/preferences/PrefData.hx
+++ b/src/ui/preferences/PrefData.hx
@@ -1,4 +1,5 @@
 package ui.preferences;
+import plugins.PluginConfig.PluginDirName;
 import plugins.PluginConfig.PluginRegName;
 import haxe.DynamicAccess;
 
@@ -202,7 +203,7 @@ typedef PrefDataImpl = {
 	/**
 		List of plugin names which have been disabled by the user.
 	**/
-	disabledPlugins: Array<PluginRegName>
+	disabledPlugins: Array<PluginDirName>
 }
 enum abstract PrefAssetOrder23(Int) from Int to Int {
 	var Custom = 0;

--- a/src/ui/preferences/PrefData.hx
+++ b/src/ui/preferences/PrefData.hx
@@ -92,6 +92,8 @@ import haxe.DynamicAccess;
 			idleTime: 0,
 			pinLayers: false,
 		},
+
+		disabledPlugins: []
 	};
 }
 typedef PrefDataImpl = {
@@ -195,6 +197,11 @@ typedef PrefDataImpl = {
 		multilineStretchStyle:Int,
 		pinLayers:Bool,
 	},
+
+	/**
+		List of plugin names which have been disabled by the user.
+	**/
+	disabledPlugins: Array<String>
 }
 enum abstract PrefAssetOrder23(Int) from Int to Int {
 	var Custom = 0;

--- a/src/ui/preferences/PrefData.hx
+++ b/src/ui/preferences/PrefData.hx
@@ -1,4 +1,5 @@
 package ui.preferences;
+import plugins.PluginConfig.PluginRegName;
 import haxe.DynamicAccess;
 
 /**
@@ -201,7 +202,7 @@ typedef PrefDataImpl = {
 	/**
 		List of plugin names which have been disabled by the user.
 	**/
-	disabledPlugins: Array<String>
+	disabledPlugins: Array<PluginRegName>
 }
 enum abstract PrefAssetOrder23(Int) from Int to Int {
 	var Custom = 0;

--- a/src/ui/preferences/PrefMenu.hx
+++ b/src/ui/preferences/PrefMenu.hx
@@ -18,7 +18,7 @@ class PrefMenu {
 		PrefMagic.build(out);
 		PrefApp.build(out);
 		PrefBackups.build(out);
-		PrefPlugins.build(out);
+		PrefPlugins.buildPreferences(out);
 		if (electron.Electron.isAvailable()) {
 			var gr = addGroup(out, "Other useful things"), el:Element;
 			//

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -39,7 +39,7 @@ class PrefPlugins {
 
 		addText(group, "Currently loaded plugins:");
 
-		for (_ => p in PluginManager.registry) {
+		for (p in PluginManager.knownPlugins) {
 			p.prefItem = new PluginPrefItemImpl(group, p);
 		}
 		

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -21,13 +21,20 @@ class PrefPlugins {
 		var legend:LegendElement = group.querySelectorAuto("legend");
 		group.classList.add("plugin-info");
 		group.setAttribute("for", p.name);
-		var syncLabelState:Void->Void = null;
+		var syncState:Void->Void = null;
 		//
 		var p_label = document.createLabelElement();
 		p_label.appendChild(document.createTextNode(p.name));
 		legend.appendChild(p_label);
-		//
-		var p_conf:Element = null;
+
+		final p_desc = document.createDivElement();
+		p_desc.classList.add("plugin-description");
+		group.appendChild(p_desc);
+
+		final p_conf:Element = document.createDivElement();
+		p_conf.classList.add("plugin-settings");
+		p_conf.setAttribute("for", p.name);
+		group.appendChild(p_conf);
 
 		legend.appendChild(document.createTextNode("("));
 		
@@ -43,7 +50,7 @@ class PrefPlugins {
 				PluginManager.disable(p.name);
 			}
 
-			syncLabelState();
+			syncState();
 
 		});
 
@@ -57,7 +64,7 @@ class PrefPlugins {
 			p_conf.clearInner();
 
 			PluginManager.reload(p.name, function(_) {
-				syncLabelState();
+				syncState();
 			});
 
 		});
@@ -68,18 +75,8 @@ class PrefPlugins {
 		legend.appendChild(reloadButtonContainer);
 
 		legend.appendChild(document.createTextNode(")"));
-
-		//
-		var p_desc = document.createDivElement();
-		p_desc.classList.add("plugin-description");
-		group.appendChild(p_desc);
-		//
-		p_conf = document.createDivElement();
-		p_conf.classList.add("plugin-settings");
-		p_conf.setAttribute("for", p.name);
-		group.appendChild(p_conf);
 		
-		syncLabelState = function() {
+		syncState = function() {
 
 			final canCleanUp = (p.data?.cleanup != null);
 			final enabled = !PluginManager.isDisabledByUser(p.name);
@@ -106,10 +103,16 @@ class PrefPlugins {
 				: "";
 
 			group.setGroupVisibility(enabled);
+			
+			if (enabled) {
+				if (p.data.buildPreferences != null) {
+					p.data.buildPreferences(p_conf);
+				}
+			}
 
 		}
 
-		syncLabelState();
+		syncState();
 	}
 	public static function build(out:Element) {
 		out = addGroup(out, "Plugins");

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -128,7 +128,7 @@ private class PrefsGroup {
 		p_conf.setAttribute("for", p.name);
 		group.appendChild(p_conf);
 
-		legend.appendChild(document.createTextNode("("));
+		legend.appendChild(document.createTextNode(" ("));
 		
 		openButton = createShellAnchor(p.dir, "open");
 		legend.appendChild(openButton);

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -39,8 +39,7 @@ class PrefPlugins {
 
 		addText(group, "Currently loaded plugins:");
 
-		for (p_name in PluginManager.pluginList) {
-			final p = PluginManager.pluginMap[p_name];
+		for (_ => p in PluginManager.pluginMap) {
 			p.prefItem = new PluginPrefItemImpl(group, p);
 		}
 		
@@ -117,7 +116,7 @@ class PluginPrefItemImpl implements PluginPrefItem {
 
 	public function sync(): Void {
 
-		final enabled = PluginManager.isEnabled(p.name);
+		final enabled = PluginManager.isEnabled(p.config.name);
 
 		p_label.classList.setTokenFlag("error", p.error != null);
 		
@@ -158,10 +157,10 @@ class PluginPrefItemImpl implements PluginPrefItem {
 		Toggle whether the linked plugin is enabled.
 	**/
 	function toggle() {
-		if (PluginManager.isEnabled(p.name)) {
-			PluginManager.disable(p.name);
+		if (PluginManager.isEnabled(p.config.name)) {
+			PluginManager.disable(p.config.name);
 		} else {
-			PluginManager.enable(p.name);
+			PluginManager.enable(p.config.name);
 		}
 	}
 
@@ -169,7 +168,7 @@ class PluginPrefItemImpl implements PluginPrefItem {
 		Reload the linked plugin from disk.
 	**/
 	function reload() {
-		PluginManager.reload(p.name, function(pluginState) {
+		PluginManager.reload(p.config.name, function(pluginState) {
 
 			p = pluginState;
 			p.prefItem = this;

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -156,7 +156,7 @@ private class PrefsGroup {
 	public function sync(): Void {
 		
 		final config = p.config;
-		final enabled = (config == null) || PluginManager.isEnabled(p.config.name);
+		final enabled = (config == null) || PluginManager.isEnabled(p);
 
 		p_label.classList.setTokenFlag("error", p.error != null);
 		
@@ -202,10 +202,10 @@ private class PrefsGroup {
 		Toggle whether the linked plugin is enabled.
 	**/
 	function toggle() {
-		if (PluginManager.isEnabled(p.config.name)) {
-			PluginManager.disable(p.config.name);
+		if (PluginManager.isEnabled(p)) {
+			PluginManager.disable(p);
 		} else {
-			PluginManager.enable(p.config.name);
+			PluginManager.enable(p);
 		}
 	}
 
@@ -238,7 +238,7 @@ private class ProjectPropsGroup {
 
 		if ((project == null)
 			|| (p.error != null)
-			|| !PluginManager.isEnabled(p.config.name)
+			|| !PluginManager.isEnabled(p)
 			|| (p.data.buildProjectProperties == null)
 		) {
 			group.remove();

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -133,14 +133,14 @@ private class PrefsGroup {
 		openButton = createShellAnchor(p.dir, "open");
 		legend.appendChild(openButton);
 
-		toggleButton = createFuncAnchor("", function(_) toggle());
+		toggleButton = createFuncAnchor("", _ -> toggle());
 
 		toggleButtonContainer = document.createSpanElement();
 		toggleButtonContainer.appendChild(document.createTextNode("; "));
 		toggleButtonContainer.appendChild(toggleButton);
 		legend.appendChild(toggleButtonContainer);
 
-		reloadButton = createFuncAnchor("reload", function(_) reload());
+		reloadButton = createFuncAnchor("reload", _ -> reload());
 
 		reloadButtonContainer = document.createSpanElement();
 		reloadButtonContainer.appendChild(document.createTextNode("; "));

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -115,8 +115,9 @@ class PluginPrefItemImpl implements PluginPrefItem {
 	}
 
 	public function sync(): Void {
-
-		final enabled = PluginManager.isEnabled(p.config.name);
+		
+		final config = p.config;
+		final enabled = (config == null) || PluginManager.isEnabled(p.config.name);
 
 		p_label.classList.setTokenFlag("error", p.error != null);
 		
@@ -127,18 +128,23 @@ class PluginPrefItemImpl implements PluginPrefItem {
 
 		reloadButtonContainer.setDisplayFlag(enabled && (p.data == null || p.canCleanUp));
 
-		var desc = p.config.description;
-		if (desc != null && NativeString.trimBoth(desc) == "") desc = null;
-		if (desc != null) p_desc.setInnerText(desc);
+		if (config != null) {
+			final desc = config.description;
+			
+			if (desc != null && NativeString.trimBoth(desc) != "") {
+				p_desc.setInnerText(desc);
+			}
+		}
 
 		toggleButton.textContent = (enabled) 
 			? "disable" 
 			: "enable";
-			
+
 		toggleButton.title = (enabled && !p.canCleanUp)
 			? "Requires a restart."
 			: "";
-
+		
+		toggleButtonContainer.setDisplayFlag(config != null);
 		group.setGroupVisibility(enabled);
 
 		if (p.canCleanUp) {

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -53,17 +53,10 @@ class PrefPlugins {
 		legend.appendChild(toggleButtonContainer);
 
 		final reloadButton = createFuncAnchor("reload", function(_) {
-
+			
 			p_conf.clearInner();
-			PluginManager.stop(p.name);
 
-			PluginManager.load(p.name, function(_) {
-				p = PluginManager.pluginMap[p.name];
-
-				if (p.data.init != null) {
-					p.data.init(p);
-				}
-				
+			PluginManager.reload(p.name, function(_) {
 				syncLabelState();
 			});
 

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -168,9 +168,7 @@ class PluginPrefItemImpl implements PluginPrefItem {
 		Reload the linked plugin from disk.
 	**/
 	function reload() {
-		PluginManager.reload(p).then(function(_) {
-			sync();
-		});
+		PluginManager.reload(p).then(_ -> sync());
 	}
 
 }

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -91,7 +91,7 @@ class PluginPrefItemImpl implements PluginPrefItem {
 
 		legend.appendChild(document.createTextNode("("));
 		
-		openButton = createShellAnchor(p.path, "open");
+		openButton = createShellAnchor(p.dir, "open");
 		legend.appendChild(openButton);
 
 		toggleButton = createFuncAnchor("", function(_) toggle());

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -39,7 +39,7 @@ class PrefPlugins {
 
 		addText(group, "Currently loaded plugins:");
 
-		for (_ => p in PluginManager.pluginMap) {
+		for (_ => p in PluginManager.registry) {
 			p.prefItem = new PluginPrefItemImpl(group, p);
 		}
 		
@@ -56,7 +56,7 @@ interface PluginPrefItem {
 
 class PluginPrefItemImpl implements PluginPrefItem {
 
-	var p:PluginState;
+	final p:PluginState;
 
 	final group:FieldSetElement;
 	final legend:LegendElement;
@@ -91,7 +91,7 @@ class PluginPrefItemImpl implements PluginPrefItem {
 
 		legend.appendChild(document.createTextNode("("));
 		
-		openButton = createShellAnchor(p.dir, "open");
+		openButton = createShellAnchor(p.path, "open");
 		legend.appendChild(openButton);
 
 		toggleButton = createFuncAnchor("", function(_) toggle());
@@ -168,13 +168,8 @@ class PluginPrefItemImpl implements PluginPrefItem {
 		Reload the linked plugin from disk.
 	**/
 	function reload() {
-		PluginManager.reload(p.config.name, function(pluginState) {
-
-			p = pluginState;
-			p.prefItem = this;
-
+		PluginManager.reload(p).then(function(_) {
 			sync();
-
 		});
 	}
 

--- a/src/ui/preferences/PrefPlugins.hx
+++ b/src/ui/preferences/PrefPlugins.hx
@@ -43,7 +43,7 @@ class PrefPlugins {
 
 		final toggleButton = createFuncAnchor("", function(_) {
 
-			if (PluginManager.isDisabledByUser(p.name)) {
+			if (!PluginManager.isEnabled(p.name)) {
 				PluginManager.enable(p.name);
 			} else {
 				p_conf.clearInner();
@@ -79,7 +79,7 @@ class PrefPlugins {
 		syncState = function() {
 
 			final canCleanUp = (p.data?.cleanup != null);
-			final enabled = !PluginManager.isDisabledByUser(p.name);
+			final enabled = PluginManager.isEnabled(p.name);
 
 			p_label.classList.setTokenFlag("error", p.error != null);
 			

--- a/src/ui/project/ProjectProperties.hx
+++ b/src/ui/project/ProjectProperties.hx
@@ -1,4 +1,6 @@
 package ui.project;
+import gml.file.GmlFile;
+import ui.preferences.PrefPlugins;
 import gml.GmlAPI;
 import haxe.Json;
 import js.html.DivElement;
@@ -220,21 +222,32 @@ class ProjectProperties {
 		buildSearch(project, out);
 		buildSyntax(project, out);
 		ui.preferences.PrefLinter.build(out, project);
+		PrefPlugins.buildProjectProperties(out, project);
 		//
 		plugins.PluginEvents.projectPropertiesBuilt({
 			project: project,
 			target: out,
 		});
 	}
-	public static function open() {
-		var kind = KProjectProperties.inst;
-		var pj = Project.current;
+
+	public static function open():Null<GmlFile> {
+
+		final kind = KProjectProperties.inst;
+		final pj = Project.current;
+
+		if (pj.path == "") {
+			return null;
+		}
+		
 		for (tab in ChromeTabs.getTabs()) {
 			if (tab.gmlFile.kind != kind) continue;
 			if ((cast tab.gmlFile.editor:KProjectPropertiesEditor).project != pj) continue;
 			tab.click();
 			return tab.gmlFile;
 		}
+
 		return kind.create("Project properties", null, pj, null);
+		
 	}
+
 }


### PR DESCRIPTION
Plugins can now be disabled rather than being forced to remove them from the directory to prevent them from being initialised.

Disabled plugins have their groups minimised by default to show this visually.

If a plugin does not implement `cleanup`, the `reload` button will not display unless the plugin has not successfully loaded at all.

Additionally, plugins that do not implement `cleanup` have a tooltip on the `disable` button to indicate that toggling them requires a restart.