### PR TITLE
fix: don't show angry error box when in dev environment

### DIFF
--- a/src/gml/Project.hx
+++ b/src/gml/Project.hx
@@ -522,7 +522,7 @@ import ui.treeview.TreeViewElement;
 	public static function openInitialProject() {
 		#if !lwedit
 		var path = moduleArgs["open"];
-		if (path != null) {
+		if (path != null && path != ".") {
 			var tmp = new Project("", false);
 			current = tmp;
 			window.setTimeout(function() {


### PR DESCRIPTION
Stops this pop-up when running directly with `npm run start`:
![image](https://github.com/user-attachments/assets/f314df1f-f4b9-4728-8276-aafe13a35e4a)

Just prevents attempting to load a file from `.`, since we can reasonably assume that one would not be trying to load GMEdit's directory as a project.