### PR TITLE
feat: keep editors' scroll positions on changing tabs

### DIFF
--- a/src/editors/Editor.hx
+++ b/src/editors/Editor.hx
@@ -16,6 +16,12 @@ class Editor {
 	
 	public var element:Element;
 	public var file:GmlFile;
+
+	/**
+		The scroll position of `element` when it was last in focus. Restored on bringing this tab
+		back into view.
+	**/
+	private var savedScrollTop:Int = 0;
 	
 	public function new(file:GmlFile) {
 		this.file = file;
@@ -40,10 +46,13 @@ class Editor {
 	public function focusGain(prev:Editor):Void {
 		if (prev.element != element) {
 			container.appendChild(element);
+			element.scrollTop = savedScrollTop;
 		}
 	}
+	
 	public function focusLost(next:Editor):Void {
 		if (next.element != element) {
+			savedScrollTop = element.scrollTop;
 			container.removeChild(element);
 		}
 	}


### PR DESCRIPTION
This means tabs such as Preferences and Project Properties don't get sent back to the top when tabbed out of and back to.